### PR TITLE
Rework and restructure to C-like

### DIFF
--- a/misc/gen-syntax.py
+++ b/misc/gen-syntax.py
@@ -184,8 +184,8 @@ def pad_prefix(txt):
 
 
 def write_output(output, txt):
-    print(txt)
-    output.write(txt + "\n")
+    args.output.write(txt + "\n")
+    logger.debug(txt)
 
 
 if __name__ == "__main__":
@@ -197,6 +197,7 @@ if __name__ == "__main__":
     p.add_argument("output", nargs="?", type=argparse.FileType("w"),
                    default=os.path.join("..", "syntax", "sqf.vim"))
     args = p.parse_args()
+    output = args.output
 
     known_words = set(sum((d.members for d in WELL_KNOWN), ()))
     commands = []
@@ -216,7 +217,7 @@ if __name__ == "__main__":
     definitions = (sqfCommand,) + WELL_KNOWN
 
     # Write output
-    write_output(args.output, HEADER.format(args.version))
+    write_output(output, HEADER.format(args.version))
 
     for defn in definitions:
         members = sorted("\\" + m if m.startswith("|") else m for m in defn.members)
@@ -225,11 +226,11 @@ if __name__ == "__main__":
 
         wrap = textwrap.wrap(text, initial_indent=prefix, subsequent_indent=prefix, width=LINE_WIDTH)
         for line in wrap:
-            write_output(args.output, line)
-        write_output(args.output, "")
+            write_output(output, line)
+        write_output(output, "")
 
-    write_output(args.output, WEIRD_MEMES)
+    write_output(output, WEIRD_MEMES)
 
     for defn in definitions:
         prefix = pad_prefix("hi def link     {}".format(defn.name))
-        write_output(args.output, "{}{}".format(prefix, defn.feature))
+        write_output(output, "{}{}".format(prefix, defn.feature))

--- a/misc/gen-syntax.py
+++ b/misc/gen-syntax.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
     args.input.close()
 
-    sqfCommand = Definition("keyword", "sqfCommand", "Special", commands)
+    sqfCommand = Definition("keyword", "sqfCommand", "Function", commands)
     definitions = (sqfCommand,) + PREDEFINED_GEN
 
     # Write output

--- a/misc/gen-syntax.py
+++ b/misc/gen-syntax.py
@@ -12,7 +12,7 @@ import attr  # from the attrs package
 
 logger = logging.getLogger()
 
-LINE_WIDTH = 78
+LINE_WIDTH = 120
 LINE_PREFIX_WIDTH = 32
 
 HEADER = """\
@@ -45,8 +45,6 @@ syn region      sqfDefine       start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip
 syn match       sqfNumber       display "\<\d\+\>"
 
 syn region      sqfLocalVar     display start="\<_\w" end="\>"
-
-syn match       sqfFunction     display "\<\w\+fnc\w\+\>"
 
 let b:current_syntax = "sqf"
 
@@ -85,6 +83,7 @@ WELL_KNOWN = (
             "execfsm",
             "execvm",
             "exitwith",
+            "private",
         ),
     ),
     Definition(

--- a/misc/gen-syntax.py
+++ b/misc/gen-syntax.py
@@ -1,159 +1,127 @@
 r"""
-Takes the output from supportInfo to build the vim syntax highlighting file.
+Takes the output from `supportInfo` command to build the vim syntax highlighting file.
 
-Do sometihng like `copyToClipboard ((supportInfo "") joinString endl)` and save your
-clipboard to a file and give the path as an argument to this script.
+Execute `copyToClipboard ((supportInfo "") joinString endl)` in Arma 3 debug console
+Save clipboard to file and give the path as an argument to this script.
 """
 
 import sys
 import os
 import argparse
 import textwrap
+import re
 import logging
 import attr  # from the attrs package
+from datetime import date
 
 logger = logging.getLogger()
 
 LINE_WIDTH = 120
-LINE_PREFIX_WIDTH = 32
-
-HEADER = """\
-" Vim syntax file
-" Language:        SQF Script (used in Bohemia Interactives ArmA/ArmA2/etc.)
-" Original Author: shreds-of-sanity@gmx.net
-" Modified By:     somebody@froghat.ca
-" Last modified for Arma 3 version {}
-
-if exists("b:current_syntax")
-  finish
-endif
-
-syn case ignore
-"""
-
-WEIRD_MEMES = r"""
-" Other weird stuff
-
-syn region      sqfString       start=+L\="+ end=+"+
-
-syn region      sqfComment      start="/\*" end="\*/" extend
-syn region      sqfCommentL     start="//" skip="\\$" end="$" keepend
-
-syn region      sqfIncluded     display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn match       sqfIncluded     display contained "<[^>]*>"
-syn match       sqfInclude      display "^\s*\(%:\|#\)\s*include\>\s*["<]" contains=sqfIncluded
-syn region      sqfPreProc      start="^\s*\(%:\|#\)\s*\(ifn\?def\|else\|endif\)" skip="\\$" end="$" keepend
-syn region      sqfDefine       start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip="\\$" end="$" keepend
-syn match       sqfNumber       display "\<\d\+\>"
-
-syn region      sqfLocalVar     display start="\<_\w" end="\>"
-
-let b:current_syntax = "sqf"
-
-hi def link     sqfComment      Comment
-hi def link     sqfCommentL     Comment
-hi def link     sqfDefine       Macro
-hi def link     sqfInclude      Include
-hi def link     sqfIncluded     String
-hi def link     sqfLocalVar     Special
-hi def link     sqfNumber       Number
-hi def link     sqfPreProc      PreProc
-hi def link     sqfString       String
-hi def link     sqfFunction     Function"""
+LINE_PREFIX_WIDTH = 28
 
 
 @attr.s(frozen=True)
 class Definition(object):
+    syn = attr.ib()
     name = attr.ib()
     feature = attr.ib()
     members = attr.ib()
 
 
-WELL_KNOWN = (
-    Definition("sqfRepeat", "Repeat", ("for", "foreach", "from", "to", "while", "do")),
-    Definition(
-        "sqfKeyword",
-        "Keyword",
-        (
-            "call",
-            "callextension",
-            "scriptdone",
-            "sleep",
-            "spawn",
-            "terminate",
-            "waituntil",
-            "execfsm",
-            "execvm",
-            "exitwith",
-            "private",
-        ),
-    ),
-    Definition(
-        "sqfStatement",
-        "Statement",
-        (
-            "commandfsm",
-            "compile",
-            "compilefinal",
-            "dofsm",
-            "preprocessfile",
-            "preprocessfilelinenumbers",
-            "count",
-        ),
-    ),
-    Definition(
-        "sqfConditional",
-        "Conditional",
-        ("if", "then", "else", "case", "switch", "default"),
-    ),
-    Definition(
-        "sqfConstant",
-        "Constant",
-        (
-            "civilian",
-            "controlnull",
-            "displaynull",
-            "east",
-            "grpnull",
-            "locationnull",
-            "netobjnull",
-            "nil",
-            "objnull",
-            "independent",
-            "resistance",
-            "scriptnull",
-            "sideunknown",
-            "tasknull",
-            "teammembernull",
-            "west",
-        ),
-    ),
-    Definition("sqfBoolean", "Boolean", ("yes", "no", "true", "false")),
-    Definition(
-        "sqfOperator",
-        "Operator",
-        (
-            "||",
-            "!",
-            "!=",
-            "%",
-            "&&",
-            "*",
-            "+",
-            "-",
-            "/",
-            ":",
-            "<",
-            "<=",
-            "==",
-            ">",
-            ">=",
-            ">>",
-            "^",
-        ),
-    ),
-    Definition("sqfExceptional", "Exceptional", ("catch", "throw", "try")),
-    Definition("sqfNamespace", "Namespace", ("with",)),
+PREDEFINED_GEN = (
+    Definition("keyword", "sqfKeyword", "Keyword", (
+        "call",
+        "callextension",
+        "scriptdone",
+        "sleep",
+        "spawn",
+        "terminate",
+        "waituntil",
+        "execfsm",
+        "execvm",
+        "exitwith",
+    )),
+    Definition("keyword", "sqfRepeat", "Repeat", (
+        "for",
+        "foreach",
+        "from",
+        "to",
+        "while",
+        "do"
+    )),
+    Definition("keyword", "sqfConditional", "Conditional", (
+        "if",
+        "then",
+        "else",
+        "case",
+        "switch",
+        "default",
+        "with",
+    )),
+    Definition("keyword", "sqfExceptional", "Exceptional", (
+        "catch",
+        "throw",
+        "try",
+    )),
+    Definition("keyword", "sqfStatement", "Statement", (
+        "commandfsm",
+        "compile",
+        "compilefinal",
+        "dofsm",
+        "preprocessfile",
+        "preprocessfilelinenumbers",
+        "count",
+    )),
+
+    Definition("keyword", "sqfConstant", "Constant", (
+        "civilian",
+        "controlnull",
+        "displaynull",
+        "east",
+        "grpnull",
+        "locationnull",
+        "netobjnull",
+        "nil",
+        "objnull",
+        "independent",
+        "resistance",
+        "scriptnull",
+        "sideunknown",
+        "tasknull",
+        "teammembernull",
+        "west",
+    )),
+    Definition("keyword", "sqfBoolean", "Boolean", (
+        "true",
+        "false",
+    )),
+    Definition("keyword", "sqfType", "Type", (
+        "private",
+    )),
+)
+
+# Defined directly in file, eg. operator matches
+PREDEFINED_NONGEN = (
+    # Operators: defined with syn match
+    "!",
+    "!=",
+    "%",
+    "&&",
+    "*",
+    "+",
+    "-",
+    "/",
+    "<",
+    "<=",
+    "==",
+    ">",
+    ">=",
+    ">>",
+    "||",
+    "^",
+    "#",
+    # None
+    ":",
 )
 
 
@@ -180,12 +148,9 @@ def parse_command(txt):
 
 
 def pad_prefix(txt):
-    return txt + (" " * (32 - len(txt)))
+    return txt + (" " * (LINE_PREFIX_WIDTH - len(txt)))
 
 
-def write_output(output, txt):
-    args.output.write(txt + "\n")
-    logger.debug(txt)
 
 
 if __name__ == "__main__":
@@ -194,43 +159,71 @@ if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("input", type=argparse.FileType("r"))
     p.add_argument("version")
-    p.add_argument("output", nargs="?", type=argparse.FileType("w"),
+    p.add_argument("output", nargs="?", type=argparse.FileType("r+"),
                    default=os.path.join("..", "syntax", "sqf.vim"))
     args = p.parse_args()
     output = args.output
 
-    known_words = set(sum((d.members for d in WELL_KNOWN), ()))
+    known_words = set(sum((d.members for d in PREDEFINED_GEN), (PREDEFINED_NONGEN)))
     commands = []
     for line in args.input:
         txt = line.strip()
         if not txt:
             logger.debug("Line contains only whitespace, skipping ...")
             continue
+
         cmd = parse_command(txt)
         if cmd is None:
             continue
         elif cmd in known_words or cmd in commands:
-            logger.info("{} already recorded as something, skipping".format(cmd))
+            logger.info("{} already recorded as something, skipping ...".format(cmd))
         else:
             commands.append(cmd)
-    sqfCommand = Definition("sqfCommand", "Function", commands)
-    definitions = (sqfCommand,) + WELL_KNOWN
+
+    args.input.close()
+
+    sqfCommand = Definition("keyword", "sqfCommand", "Special", commands)
+    definitions = (sqfCommand,) + PREDEFINED_GEN
 
     # Write output
-    write_output(output, HEADER.format(args.version))
+    data = output.read()
 
+    data = re.sub(r"\" Version:      (.+)",
+                  "\" Version:      {} [Arma 3 v{}]".format(date.today(), args.version),
+                  data)
+
+    defnlines = []
     for defn in definitions:
         members = sorted("\\" + m if m.startswith("|") else m for m in defn.members)
         text = " ".join(members)
-        prefix = pad_prefix("syn keyword     {} ".format(defn.name))
+        prefix = pad_prefix("syn {} {} ".format(defn.syn, defn.name))
 
         wrap = textwrap.wrap(text, initial_indent=prefix, subsequent_indent=prefix, width=LINE_WIDTH)
         for line in wrap:
-            write_output(output, line)
-        write_output(output, "")
+            defnlines.append(line)
 
-    write_output(output, WEIRD_MEMES)
+        defnlines.append("")
 
+    defntext = "\n".join(defnlines[:-1])  # [:-1] to remove last new-line
+    data = re.sub(r"(?is)\" START GEN(.+)\" END GEN",
+                  "\" START GEN\n{}\n\" END GEN".format(defntext),
+                  data)
+
+    defnlines = []
     for defn in definitions:
-        prefix = pad_prefix("hi def link     {}".format(defn.name))
-        write_output(output, "{}{}".format(prefix, defn.feature))
+        prefix = pad_prefix("hi def link {}".format(defn.name))
+        defnlines.append("{}{}".format(prefix, defn.feature))
+
+    defntext = "\n".join(defnlines)
+    data = re.sub(r"(?is)\" START HI GEN(.+)\" END HI GEN",
+                  "\" START HI GEN\n{}\n\" END HI GEN".format(defntext),
+                  data)
+
+    output.seek(0)
+    output.write(data)
+    output.truncate()
+    output.close()
+
+    logger.debug(txt)
+
+    sys.exit(0)

--- a/syntax/sqf.vim
+++ b/syntax/sqf.vim
@@ -2,7 +2,7 @@
 " Language:        SQF Script (used in Bohemia Interactives ArmA/ArmA2/etc.)
 " Original Author: shreds-of-sanity@gmx.net
 " Modified By:     somebody@froghat.ca
-" Last modified for Arma 3 version 1.88
+" Last modified for Arma 3 version 1.94
 
 if exists("b:current_syntax")
   finish
@@ -10,841 +10,423 @@ endif
 
 syn case ignore
 
-syn keyword     sqfCommand      abs acctime acos action actionids actionkeys
-syn keyword     sqfCommand      actionkeysimages actionkeysnames
-syn keyword     sqfCommand      actionkeysnamesarray actionname actionparams
-syn keyword     sqfCommand      activateaddons activatedaddons activatekey
-syn keyword     sqfCommand      add3denconnection add3deneventhandler
-syn keyword     sqfCommand      add3denlayer addaction addbackpack
-syn keyword     sqfCommand      addbackpackcargo addbackpackcargoglobal
-syn keyword     sqfCommand      addbackpackglobal addcamshake addcuratoraddons
-syn keyword     sqfCommand      addcuratorcameraarea addcuratoreditableobjects
-syn keyword     sqfCommand      addcuratoreditingarea addcuratorpoints
-syn keyword     sqfCommand      addeditorobject addeventhandler addforce
-syn keyword     sqfCommand      addforcegeneratorrtd addgoggles addgroupicon
-syn keyword     sqfCommand      addhandgunitem addheadgear additem
-syn keyword     sqfCommand      additemcargo additemcargoglobal additempool
-syn keyword     sqfCommand      additemtobackpack additemtouniform
-syn keyword     sqfCommand      additemtovest addlivestats addmagazine
-syn keyword     sqfCommand      addmagazineammocargo addmagazinecargo
-syn keyword     sqfCommand      addmagazinecargoglobal addmagazineglobal
-syn keyword     sqfCommand      addmagazinepool addmagazines addmagazineturret
-syn keyword     sqfCommand      addmenu addmenuitem addmissioneventhandler
-syn keyword     sqfCommand      addmpeventhandler addmusiceventhandler
-syn keyword     sqfCommand      addownedmine addplayerscores
-syn keyword     sqfCommand      addprimaryweaponitem
-syn keyword     sqfCommand      addpublicvariableeventhandler addrating
-syn keyword     sqfCommand      addresources addscore addscoreside
-syn keyword     sqfCommand      addsecondaryweaponitem addswitchableunit
-syn keyword     sqfCommand      addteammember addtoremainscollector addtorque
-syn keyword     sqfCommand      adduniform addvehicle addvest addwaypoint
-syn keyword     sqfCommand      addweapon addweaponcargo addweaponcargoglobal
-syn keyword     sqfCommand      addweaponglobal addweaponitem addweaponpool
-syn keyword     sqfCommand      addweaponturret admin agent agents agltoasl
-syn keyword     sqfCommand      aimedattarget aimpos airdensitycurvertd
-syn keyword     sqfCommand      airdensityrtd airplanethrottle airportside
-syn keyword     sqfCommand      aisfinishheal alive all3denentities
-syn keyword     sqfCommand      allairports allcontrols allcurators
-syn keyword     sqfCommand      allcutlayers alldead alldeadmen alldisplays
-syn keyword     sqfCommand      allgroups allmapmarkers allmines
-syn keyword     sqfCommand      allmissionobjects allow3dmode
-syn keyword     sqfCommand      allowcrewinimmobile
-syn keyword     sqfCommand      allowcuratorlogicignoreareas allowdamage
-syn keyword     sqfCommand      allowdammage allowfileoperations allowfleeing
-syn keyword     sqfCommand      allowgetin allowsprint allplayers
-syn keyword     sqfCommand      allsimpleobjects allsites allturrets allunits
-syn keyword     sqfCommand      allunitsuav allvariables ammo ammoonpylon and
-syn keyword     sqfCommand      animate animatebay animatedoor animatepylon
-syn keyword     sqfCommand      animatesource animationnames animationphase
-syn keyword     sqfCommand      animationsourcephase animationstate append
-syn keyword     sqfCommand      apply armorypoints arrayintersect asin
-syn keyword     sqfCommand      asltoagl asltoatl assert assignascargo
-syn keyword     sqfCommand      assignascargoindex assignascommander
-syn keyword     sqfCommand      assignasdriver assignasgunner assignasturret
-syn keyword     sqfCommand      assigncurator assignedcargo assignedcommander
-syn keyword     sqfCommand      assigneddriver assignedgunner assigneditems
-syn keyword     sqfCommand      assignedtarget assignedteam assignedvehicle
-syn keyword     sqfCommand      assignedvehiclerole assignitem assignteam
-syn keyword     sqfCommand      assigntoairport atan atan2 atg atltoasl
-syn keyword     sqfCommand      attachedobject attachedobjects attachedto
-syn keyword     sqfCommand      attachobject attachto attackenabled backpack
-syn keyword     sqfCommand      backpackcargo backpackcontainer backpackitems
-syn keyword     sqfCommand      backpackmagazines backpackspacefor behaviour
-syn keyword     sqfCommand      benchmark binocular blufor boundingbox
-syn keyword     sqfCommand      boundingboxreal boundingcenter breakout
-syn keyword     sqfCommand      breakto briefingname buildingexit buildingpos
-syn keyword     sqfCommand      buldozer_enableroaddiag
-syn keyword     sqfCommand      buldozer_isenabledroaddiag
-syn keyword     sqfCommand      buldozer_loadnewroads buldozer_reloadopermap
-syn keyword     sqfCommand      buttonaction buttonsetaction cadetmode
-syn keyword     sqfCommand      calculateplayervisibilitybyfriendly camcommand
-syn keyword     sqfCommand      camcommit camcommitprepared camcommitted
-syn keyword     sqfCommand      camconstuctionsetparams camcreate camdestroy
-syn keyword     sqfCommand      cameraeffect cameraeffectenablehud
-syn keyword     sqfCommand      camerainterest cameraon cameraview
-syn keyword     sqfCommand      campaignconfigfile campreload campreloaded
-syn keyword     sqfCommand      campreparebank campreparedir campreparedive
-syn keyword     sqfCommand      campreparefocus campreparefov
-syn keyword     sqfCommand      campreparefovrange campreparepos
-syn keyword     sqfCommand      campreparerelpos campreparetarget camsetbank
-syn keyword     sqfCommand      camsetdir camsetdive camsetfocus camsetfov
-syn keyword     sqfCommand      camsetfovrange camsetpos camsetrelpos
-syn keyword     sqfCommand      camsettarget camtarget camusenvg canadd
-syn keyword     sqfCommand      canadditemtobackpack canadditemtouniform
-syn keyword     sqfCommand      canadditemtovest cancelsimpletaskdestination
-syn keyword     sqfCommand      canfire canmove canslingload canstand
-syn keyword     sqfCommand      cansuspend cantriggerdynamicsimulation
-syn keyword     sqfCommand      canunloadincombat canvehiclecargo captive
-syn keyword     sqfCommand      captivenum cbchecked cbsetchecked ceil
-syn keyword     sqfCommand      channelenabled cheatsenabled checkaifeature
-syn keyword     sqfCommand      checkvisibility classname clear3denattribute
-syn keyword     sqfCommand      clear3deninventory clearallitemsfrombackpack
-syn keyword     sqfCommand      clearbackpackcargo clearbackpackcargoglobal
-syn keyword     sqfCommand      clearforcesrtd cleargroupicons clearitemcargo
-syn keyword     sqfCommand      clearitemcargoglobal clearitempool
-syn keyword     sqfCommand      clearmagazinecargo clearmagazinecargoglobal
-syn keyword     sqfCommand      clearmagazinepool clearoverlay clearradio
-syn keyword     sqfCommand      clearweaponcargo clearweaponcargoglobal
-syn keyword     sqfCommand      clearweaponpool clientowner closedialog
-syn keyword     sqfCommand      closedisplay closeoverlay collapseobjecttree
-syn keyword     sqfCommand      collect3denhistory collectivertd combatmode
-syn keyword     sqfCommand      commandartilleryfire commandchat commander
-syn keyword     sqfCommand      commandfire commandfollow commandgetout
-syn keyword     sqfCommand      commandingmenu commandmove commandradio
-syn keyword     sqfCommand      commandstop commandsuppressivefire
-syn keyword     sqfCommand      commandtarget commandwatch comment
-syn keyword     sqfCommand      commitoverlay completedfsm composetext
-syn keyword     sqfCommand      configclasses configfile confighierarchy
-syn keyword     sqfCommand      configname confignull configproperties
-syn keyword     sqfCommand      configsourceaddonlist configsourcemod
-syn keyword     sqfCommand      configsourcemodlist confirmsensortarget
-syn keyword     sqfCommand      connectterminaltouav controlsgroupctrl
-syn keyword     sqfCommand      copyfromclipboard copytoclipboard
-syn keyword     sqfCommand      copywaypoints cos countenemy countfriendly
-syn keyword     sqfCommand      countside counttype countunknown
-syn keyword     sqfCommand      create3dencomposition create3denentity
-syn keyword     sqfCommand      createagent createcenter createdialog
-syn keyword     sqfCommand      creatediarylink creatediaryrecord
-syn keyword     sqfCommand      creatediarysubject createdisplay
-syn keyword     sqfCommand      creategeardialog creategroup
-syn keyword     sqfCommand      createguardedpoint createlocation createmarker
-syn keyword     sqfCommand      createmarkerlocal createmenu createmine
-syn keyword     sqfCommand      createmissiondisplay creatempcampaigndisplay
-syn keyword     sqfCommand      createsimpleobject createsimpletask createsite
-syn keyword     sqfCommand      createsoundsource createtask createteam
-syn keyword     sqfCommand      createtrigger createunit createvehicle
-syn keyword     sqfCommand      createvehiclecrew createvehiclelocal crew
-syn keyword     sqfCommand      ctaddheader ctaddrow ctclear ctcursel ctdata
-syn keyword     sqfCommand      ctfindheaderrows ctfindrowheader
-syn keyword     sqfCommand      ctheadercontrols ctheadercount ctremoveheaders
-syn keyword     sqfCommand      ctremoverows ctrlactivate ctrladdeventhandler
-syn keyword     sqfCommand      ctrlangle ctrlanimatemodel
-syn keyword     sqfCommand      ctrlanimationphasemodel ctrlautoscrolldelay
-syn keyword     sqfCommand      ctrlautoscrollrewind ctrlautoscrollspeed
-syn keyword     sqfCommand      ctrlchecked ctrlclassname ctrlcommit
-syn keyword     sqfCommand      ctrlcommitted ctrlcreate ctrldelete ctrlenable
-syn keyword     sqfCommand      ctrlenabled ctrlfade ctrlhtmlloaded ctrlidc
-syn keyword     sqfCommand      ctrlidd ctrlmapanimadd ctrlmapanimclear
-syn keyword     sqfCommand      ctrlmapanimcommit ctrlmapanimdone
-syn keyword     sqfCommand      ctrlmapcursor ctrlmapmouseover ctrlmapscale
-syn keyword     sqfCommand      ctrlmapscreentoworld ctrlmapworldtoscreen
-syn keyword     sqfCommand      ctrlmodel ctrlmodeldirandup ctrlmodelscale
-syn keyword     sqfCommand      ctrlparent ctrlparentcontrolsgroup
-syn keyword     sqfCommand      ctrlposition ctrlremovealleventhandlers
-syn keyword     sqfCommand      ctrlremoveeventhandler ctrlscale
-syn keyword     sqfCommand      ctrlsetactivecolor ctrlsetangle
-syn keyword     sqfCommand      ctrlsetautoscrolldelay ctrlsetautoscrollrewind
-syn keyword     sqfCommand      ctrlsetautoscrollspeed ctrlsetbackgroundcolor
-syn keyword     sqfCommand      ctrlsetchecked ctrlsetdisabledcolor
-syn keyword     sqfCommand      ctrlseteventhandler ctrlsetfade ctrlsetfocus
-syn keyword     sqfCommand      ctrlsetfont ctrlsetfonth1 ctrlsetfonth1b
-syn keyword     sqfCommand      ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3
-syn keyword     sqfCommand      ctrlsetfonth3b ctrlsetfonth4 ctrlsetfonth4b
-syn keyword     sqfCommand      ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6
-syn keyword     sqfCommand      ctrlsetfonth6b ctrlsetfontheight
-syn keyword     sqfCommand      ctrlsetfontheighth1 ctrlsetfontheighth2
-syn keyword     sqfCommand      ctrlsetfontheighth3 ctrlsetfontheighth4
-syn keyword     sqfCommand      ctrlsetfontheighth5 ctrlsetfontheighth6
-syn keyword     sqfCommand      ctrlsetfontheightsecondary ctrlsetfontp
-syn keyword     sqfCommand      ctrlsetfontpb ctrlsetfontsecondary
-syn keyword     sqfCommand      ctrlsetforegroundcolor ctrlsetmodel
-syn keyword     sqfCommand      ctrlsetmodeldirandup ctrlsetmodelscale
-syn keyword     sqfCommand      ctrlsetpixelprecision ctrlsetposition
-syn keyword     sqfCommand      ctrlsetscale ctrlsetstructuredtext ctrlsettext
-syn keyword     sqfCommand      ctrlsettextcolor ctrlsettextcolorsecondary
-syn keyword     sqfCommand      ctrlsettextsecondary ctrlsettooltip
-syn keyword     sqfCommand      ctrlsettooltipcolorbox
-syn keyword     sqfCommand      ctrlsettooltipcolorshade
-syn keyword     sqfCommand      ctrlsettooltipcolortext ctrlshow ctrlshown
-syn keyword     sqfCommand      ctrltext ctrltextheight ctrltextsecondary
-syn keyword     sqfCommand      ctrltextwidth ctrltype ctrlvisible
-syn keyword     sqfCommand      ctrowcontrols ctrowcount ctsetcursel ctsetdata
-syn keyword     sqfCommand      ctsetheadertemplate ctsetrowtemplate
-syn keyword     sqfCommand      ctsetvalue ctvalue curatoraddons curatorcamera
-syn keyword     sqfCommand      curatorcameraarea curatorcameraareaceiling
-syn keyword     sqfCommand      curatorcoef curatoreditableobjects
-syn keyword     sqfCommand      curatoreditingarea curatoreditingareatype
-syn keyword     sqfCommand      curatormouseover curatorpoints
-syn keyword     sqfCommand      curatorregisteredobjects curatorselected
-syn keyword     sqfCommand      curatorwaypointcost current3denoperation
-syn keyword     sqfCommand      currentchannel currentcommand currentmagazine
-syn keyword     sqfCommand      currentmagazinedetail
-syn keyword     sqfCommand      currentmagazinedetailturret
-syn keyword     sqfCommand      currentmagazineturret currentmuzzle
-syn keyword     sqfCommand      currentnamespace currenttask currenttasks
-syn keyword     sqfCommand      currentthrowable currentvisionmode
-syn keyword     sqfCommand      currentwaypoint currentweapon
-syn keyword     sqfCommand      currentweaponmode currentweaponturret
-syn keyword     sqfCommand      currentzeroing cursorobject cursortarget
-syn keyword     sqfCommand      customchat customradio cutfadeout cutobj
-syn keyword     sqfCommand      cutrsc cuttext damage date datetonumber
-syn keyword     sqfCommand      daytime deactivatekey debriefingtext debugfsm
-syn keyword     sqfCommand      debuglog deg delete3denentities deleteat
-syn keyword     sqfCommand      deletecenter deletecollection
-syn keyword     sqfCommand      deleteeditorobject deletegroup
-syn keyword     sqfCommand      deletegroupwhenempty deleteidentity
-syn keyword     sqfCommand      deletelocation deletemarker deletemarkerlocal
-syn keyword     sqfCommand      deleterange deleteresources deletesite
-syn keyword     sqfCommand      deletestatus deleteteam deletevehicle
-syn keyword     sqfCommand      deletevehiclecrew deletewaypoint detach
-syn keyword     sqfCommand      detectedmines diag_activemissionfsms
-syn keyword     sqfCommand      diag_activescripts diag_activesqfscripts
-syn keyword     sqfCommand      diag_activesqsscripts diag_codeperformance
-syn keyword     sqfCommand      diag_dynamicsimulationend diag_fps diag_fpsmin
-syn keyword     sqfCommand      diag_frameno diag_lightnewload diag_log
-syn keyword     sqfCommand      diag_setlightnew diag_ticktime dialog
-syn keyword     sqfCommand      diarysubjectexists didjip didjipowner
-syn keyword     sqfCommand      difficulty difficultyenabled
-syn keyword     sqfCommand      difficultyenabledrtd difficultyoption
-syn keyword     sqfCommand      direction directsay disableai
-syn keyword     sqfCommand      disablecollisionwith disableconversation
-syn keyword     sqfCommand      disabledebriefingstats disablemapindicators
-syn keyword     sqfCommand      disablenvgequipment disableremotesensors
-syn keyword     sqfCommand      disableserialization disabletiequipment
-syn keyword     sqfCommand      disableuavconnectability disableuserinput
-syn keyword     sqfCommand      displayaddeventhandler displayctrl
-syn keyword     sqfCommand      displayparent displayremovealleventhandlers
-syn keyword     sqfCommand      displayremoveeventhandler
-syn keyword     sqfCommand      displayseteventhandler dissolveteam distance
-syn keyword     sqfCommand      distance2d distancesqr distributionregion
-syn keyword     sqfCommand      do3denaction doartilleryfire dofire dofollow
-syn keyword     sqfCommand      dogetout domove doorphase dostop
-syn keyword     sqfCommand      dosuppressivefire dotarget dowatch drawarrow
-syn keyword     sqfCommand      drawellipse drawicon drawicon3d drawline
-syn keyword     sqfCommand      drawline3d drawlink drawlocation drawpolygon
-syn keyword     sqfCommand      drawrectangle drawtriangle driver drop
-syn keyword     sqfCommand      dynamicsimulationdistance
-syn keyword     sqfCommand      dynamicsimulationdistancecoef
-syn keyword     sqfCommand      dynamicsimulationenabled
-syn keyword     sqfCommand      dynamicsimulationsystemenabled echo
-syn keyword     sqfCommand      edit3denmissionattributes editobject
-syn keyword     sqfCommand      editorseteventhandler effectivecommander
-syn keyword     sqfCommand      emptypositions enableai enableaifeature
-syn keyword     sqfCommand      enableaimprecision enableattack
-syn keyword     sqfCommand      enableaudiofeature enableautostartuprtd
-syn keyword     sqfCommand      enableautotrimrtd enablecamshake
-syn keyword     sqfCommand      enablecaustics enablechannel
-syn keyword     sqfCommand      enablecollisionwith enablecopilot
-syn keyword     sqfCommand      enabledebriefingstats enablediaglegend
-syn keyword     sqfCommand      enabledynamicsimulation
-syn keyword     sqfCommand      enabledynamicsimulationsystem enableenddialog
-syn keyword     sqfCommand      enableengineartillery enableenvironment
-syn keyword     sqfCommand      enablefatigue enablegunlights
-syn keyword     sqfCommand      enableinfopanelcomponent enableirlasers
-syn keyword     sqfCommand      enablemimics enablepersonturret enableradio
-syn keyword     sqfCommand      enablereload enableropeattach
-syn keyword     sqfCommand      enablesatnormalondetail enablesaving
-syn keyword     sqfCommand      enablesentences enablesimulation
-syn keyword     sqfCommand      enablesimulationglobal enablestamina
-syn keyword     sqfCommand      enablestressdamage enableteamswitch
-syn keyword     sqfCommand      enabletraffic enableuavconnectability
-syn keyword     sqfCommand      enableuavwaypoints enablevehiclecargo
-syn keyword     sqfCommand      enablevehiclesensor enableweapondisassembly
-syn keyword     sqfCommand      endl endloadingscreen endmission engineon
-syn keyword     sqfCommand      enginesisonrtd enginespowerrtd enginesrpmrtd
-syn keyword     sqfCommand      enginestorquertd entities environmentenabled
-syn keyword     sqfCommand      estimatedendservertime estimatedtimeleft
-syn keyword     sqfCommand      evalobjectargument everybackpack
-syn keyword     sqfCommand      everycontainer exec execeditorscript exit exp
-syn keyword     sqfCommand      expecteddestination exportjipmessages
-syn keyword     sqfCommand      eyedirection eyepos face faction fademusic
-syn keyword     sqfCommand      faderadio fadesound fadespeech failmission
-syn keyword     sqfCommand      fillweaponsfrompool find findcover finddisplay
-syn keyword     sqfCommand      findeditorobject findemptyposition
-syn keyword     sqfCommand      findemptypositionready findif findnearestenemy
-syn keyword     sqfCommand      finishmissioninit finite fire fireattarget
-syn keyword     sqfCommand      firstbackpack flag flaganimationphase
-syn keyword     sqfCommand      flagowner flagside flagtexture fleeing floor
-syn keyword     sqfCommand      flyinheight flyinheightasl fog fogforecast
-syn keyword     sqfCommand      fogparams forceadduniform forceatpositionrtd
-syn keyword     sqfCommand      forcedmap forceend forceflagtexture
-syn keyword     sqfCommand      forcefollowroad forcegeneratorrtd forcemap
-syn keyword     sqfCommand      forcerespawn forcespeed forcewalk
-syn keyword     sqfCommand      forceweaponfire forceweatherchange
-syn keyword     sqfCommand      foreachmember foreachmemberagent
-syn keyword     sqfCommand      foreachmemberteam forgettarget format
-syn keyword     sqfCommand      formation formationdirection formationleader
-syn keyword     sqfCommand      formationmembers formationposition
-syn keyword     sqfCommand      formationtask formattext formleader freelook
-syn keyword     sqfCommand      fromeditor fuel fullcrew gearidcammocount
-syn keyword     sqfCommand      gearslotammocount gearslotdata
-syn keyword     sqfCommand      get3denactionstate get3denattribute
-syn keyword     sqfCommand      get3dencamera get3denconnections get3denentity
-syn keyword     sqfCommand      get3denentityid get3dengrid
-syn keyword     sqfCommand      get3deniconsvisible get3denlayerentities
-syn keyword     sqfCommand      get3denlinesvisible get3denmissionattribute
-syn keyword     sqfCommand      get3denmouseover get3denselected getaimingcoef
-syn keyword     sqfCommand      getallenvsoundcontrollers
-syn keyword     sqfCommand      getallhitpointsdamage getallownedmines
-syn keyword     sqfCommand      getallsoundcontrollers getammocargo
-syn keyword     sqfCommand      getanimaimprecision getanimspeedcoef getarray
-syn keyword     sqfCommand      getartilleryammo getartillerycomputersettings
-syn keyword     sqfCommand      getartilleryeta getassignedcuratorlogic
-syn keyword     sqfCommand      getassignedcuratorunit getbackpackcargo
-syn keyword     sqfCommand      getbleedingremaining getburningvalue
-syn keyword     sqfCommand      getcalculateplayervisibilitybyfriendly
-syn keyword     sqfCommand      getcameraviewdirection getcargoindex
-syn keyword     sqfCommand      getcenterofmass getclientstate
-syn keyword     sqfCommand      getclientstatenumber
-syn keyword     sqfCommand      getcompatiblepylonmagazines getconnecteduav
-syn keyword     sqfCommand      getcontainermaxload getcursorobjectparams
-syn keyword     sqfCommand      getcustomaimcoef getcustomsoundcontroller
-syn keyword     sqfCommand      getcustomsoundcontrollercount getdammage
-syn keyword     sqfCommand      getdescription getdir getdirvisual
-syn keyword     sqfCommand      getdlcassetsusage getdlcassetsusagebyname
-syn keyword     sqfCommand      getdlcs getdlcusagetime geteditorcamera
-syn keyword     sqfCommand      geteditormode geteditorobjectscope
-syn keyword     sqfCommand      getelevationoffset getenginetargetrpmrtd
-syn keyword     sqfCommand      getenvsoundcontroller getfatigue
-syn keyword     sqfCommand      getfieldmanualstartpage getforcedflagtexture
-syn keyword     sqfCommand      getfriend getfsmvariable getfuelcargo
-syn keyword     sqfCommand      getgroupicon getgroupiconparams getgroupicons
-syn keyword     sqfCommand      gethidefrom gethit gethitindex
-syn keyword     sqfCommand      gethitpointdamage getitemcargo
-syn keyword     sqfCommand      getmagazinecargo getmarkercolor getmarkerpos
-syn keyword     sqfCommand      getmarkersize getmarkertype getmass
-syn keyword     sqfCommand      getmissionconfig getmissionconfigvalue
-syn keyword     sqfCommand      getmissiondlcs getmissionlayerentities
-syn keyword     sqfCommand      getmissionlayers getmodelinfo getmouseposition
-syn keyword     sqfCommand      getmusicplayedtime getnumber getobjectargument
-syn keyword     sqfCommand      getobjectchildren getobjectdlc
-syn keyword     sqfCommand      getobjectmaterials getobjectproxy
-syn keyword     sqfCommand      getobjecttextures getobjecttype
-syn keyword     sqfCommand      getobjectviewdistance getoxygenremaining
-syn keyword     sqfCommand      getpersonuseddlcs getpilotcameradirection
-syn keyword     sqfCommand      getpilotcameraposition getpilotcamerarotation
-syn keyword     sqfCommand      getpilotcameratarget getplatenumber
-syn keyword     sqfCommand      getplayerchannel getplayerscores getplayeruid
-syn keyword     sqfCommand      getpos getposasl getposaslvisual getposaslw
-syn keyword     sqfCommand      getposatl getposatlvisual getposvisual
-syn keyword     sqfCommand      getposworld getpylonmagazines getreldir
-syn keyword     sqfCommand      getrelpos getremotesensorsdisabled
-syn keyword     sqfCommand      getrepaircargo getresolution getrotorbrakertd
-syn keyword     sqfCommand      getshadowdistance getshotparents getslingload
-syn keyword     sqfCommand      getsoundcontroller getsoundcontrollerresult
-syn keyword     sqfCommand      getspeed getstamina getstatvalue
-syn keyword     sqfCommand      getsuppression getterraingrid
-syn keyword     sqfCommand      getterrainheightasl gettext
-syn keyword     sqfCommand      gettotaldlcusagetime gettrimoffsetrtd
-syn keyword     sqfCommand      getunitloadout getunittrait getusermfdtext
-syn keyword     sqfCommand      getusermfdvalue getvariable getvehiclecargo
-syn keyword     sqfCommand      getweaponcargo getweaponsway
-syn keyword     sqfCommand      getwingsorientationrtd getwingspositionrtd
-syn keyword     sqfCommand      getwppos glanceat globalchat globalradio
-syn keyword     sqfCommand      goggles goto group groupchat groupfromnetid
-syn keyword     sqfCommand      groupiconselectable groupiconsvisible groupid
-syn keyword     sqfCommand      groupowner groupradio groupselectedunits
-syn keyword     sqfCommand      groupselectunit gunner gusts halt handgunitems
-syn keyword     sqfCommand      handgunmagazine handgunweapon handshit
-syn keyword     sqfCommand      hasinterface haspilotcamera hasweapon
-syn keyword     sqfCommand      hcallgroups hcgroupparams hcleader
-syn keyword     sqfCommand      hcremoveallgroups hcremovegroup hcselected
-syn keyword     sqfCommand      hcselectgroup hcsetgroup hcshowbar hcshownbar
-syn keyword     sqfCommand      headgear hidebody hideobject hideobjectglobal
-syn keyword     sqfCommand      hideselection hint hintc hintcadet hintsilent
-syn keyword     sqfCommand      hmd hostmission htmlload hudmovementlevels
-syn keyword     sqfCommand      humidity image importallgroups importance in
-syn keyword     sqfCommand      inarea inareaarray incapacitatedstate inflame
-syn keyword     sqfCommand      inflamed infopanel infopanelcomponentenabled
-syn keyword     sqfCommand      infopanelcomponents infopanels
-syn keyword     sqfCommand      ingameuiseteventhandler inheritsfrom
-syn keyword     sqfCommand      initambientlife inpolygon inputaction
-syn keyword     sqfCommand      inrangeofartillery inserteditorobject
-syn keyword     sqfCommand      intersect is3den is3denmultiplayer
-syn keyword     sqfCommand      isabletobreathe isagent isaimprecisionenabled
-syn keyword     sqfCommand      isarray isautohoveron isautonomous
-syn keyword     sqfCommand      isautostartupenabledrtd isautotest
-syn keyword     sqfCommand      isautotrimonrtd isbleeding isburning isclass
-syn keyword     sqfCommand      iscollisionlighton iscopilotenabled
-syn keyword     sqfCommand      isdamageallowed isdedicated isdlcavailable
-syn keyword     sqfCommand      isengineon isequalto isequaltype
-syn keyword     sqfCommand      isequaltypeall isequaltypeany isequaltypearray
-syn keyword     sqfCommand      isequaltypeparams isfilepatchingenabled
-syn keyword     sqfCommand      isflashlighton isflatempty isforcedwalk
-syn keyword     sqfCommand      isformationleader isgroupdeletedwhenempty
-syn keyword     sqfCommand      ishidden isinremainscollector
-syn keyword     sqfCommand      isinstructorfigureenabled isirlaseron
-syn keyword     sqfCommand      iskeyactive iskindof islaseron islighton
-syn keyword     sqfCommand      islocalized ismanualfire ismarkedforcollection
-syn keyword     sqfCommand      ismultiplayer ismultiplayersolo isnil isnull
-syn keyword     sqfCommand      isnumber isobjecthidden isobjectrtd isonroad
-syn keyword     sqfCommand      ispipenabled isplayer isrealtime
-syn keyword     sqfCommand      isremoteexecuted isremoteexecutedjip
-syn keyword     sqfCommand      issensortargetconfirmed isserver
-syn keyword     sqfCommand      isshowing3dicons issimpleobject
-syn keyword     sqfCommand      issprintallowed isstaminaenabled
-syn keyword     sqfCommand      issteammission isstreamfriendlyuienabled
-syn keyword     sqfCommand      isstressdamageenabled istext istouchingground
-syn keyword     sqfCommand      isturnedout istuthintsenabled isuavconnectable
-syn keyword     sqfCommand      isuavconnected isuicontext isuniformallowed
-syn keyword     sqfCommand      isvehiclecargo isvehicleradaron
-syn keyword     sqfCommand      isvehiclesensorenabled iswalking
-syn keyword     sqfCommand      isweapondeployed isweaponrested itemcargo
-syn keyword     sqfCommand      items itemswithmagazines join joinas
-syn keyword     sqfCommand      joinassilent joinsilent joinstring
-syn keyword     sqfCommand      kbadddatabase kbadddatabasetargets kbaddtopic
-syn keyword     sqfCommand      kbhastopic kbreact kbremovetopic kbtell
-syn keyword     sqfCommand      kbwassaid keyimage keyname knowsabout land
-syn keyword     sqfCommand      landat landresult language lasertarget lbadd
-syn keyword     sqfCommand      lbclear lbcolor lbcolorright lbcursel lbdata
-syn keyword     sqfCommand      lbdelete lbisselected lbpicture lbpictureright
-syn keyword     sqfCommand      lbselection lbsetcolor lbsetcolorright
-syn keyword     sqfCommand      lbsetcursel lbsetdata lbsetpicture
-syn keyword     sqfCommand      lbsetpicturecolor lbsetpicturecolordisabled
-syn keyword     sqfCommand      lbsetpicturecolorselected lbsetpictureright
-syn keyword     sqfCommand      lbsetpicturerightcolor
-syn keyword     sqfCommand      lbsetpicturerightcolordisabled
-syn keyword     sqfCommand      lbsetpicturerightcolorselected
-syn keyword     sqfCommand      lbsetselectcolor lbsetselectcolorright
-syn keyword     sqfCommand      lbsetselected lbsettext lbsettextright
-syn keyword     sqfCommand      lbsettooltip lbsetvalue lbsize lbsort
-syn keyword     sqfCommand      lbsortbyvalue lbtext lbtextright lbvalue
-syn keyword     sqfCommand      leader leaderboarddeinit leaderboardgetrows
-syn keyword     sqfCommand      leaderboardinit leaderboardrequestrowsfriends
-syn keyword     sqfCommand      leaderboardrequestrowsglobal
-syn keyword     sqfCommand      leaderboardrequestrowsglobalarounduser
-syn keyword     sqfCommand      leaderboardsrequestuploadscore
-syn keyword     sqfCommand      leaderboardsrequestuploadscorekeepbest
-syn keyword     sqfCommand      leaderboardstate leavevehicle librarycredits
-syn keyword     sqfCommand      librarydisclaimers lifestate lightattachobject
-syn keyword     sqfCommand      lightdetachobject lightison lightnings
-syn keyword     sqfCommand      limitspeed linearconversion linebreak
-syn keyword     sqfCommand      lineintersects lineintersectsobjs
-syn keyword     sqfCommand      lineintersectssurfaces lineintersectswith
-syn keyword     sqfCommand      linkitem list listobjects listremotetargets
-syn keyword     sqfCommand      listvehiclesensors ln lnbaddarray lnbaddcolumn
-syn keyword     sqfCommand      lnbaddrow lnbclear lnbcolor lnbcolorright
-syn keyword     sqfCommand      lnbcurselrow lnbdata lnbdeletecolumn
-syn keyword     sqfCommand      lnbdeleterow lnbgetcolumnsposition lnbpicture
-syn keyword     sqfCommand      lnbpictureright lnbsetcolor lnbsetcolorright
-syn keyword     sqfCommand      lnbsetcolumnspos lnbsetcurselrow lnbsetdata
-syn keyword     sqfCommand      lnbsetpicture lnbsetpicturecolor
-syn keyword     sqfCommand      lnbsetpicturecolorright
-syn keyword     sqfCommand      lnbsetpicturecolorselected
-syn keyword     sqfCommand      lnbsetpicturecolorselectedright
-syn keyword     sqfCommand      lnbsetpictureright lnbsettext lnbsettextright
-syn keyword     sqfCommand      lnbsetvalue lnbsize lnbsort lnbsortbyvalue
-syn keyword     sqfCommand      lnbtext lnbtextright lnbvalue load loadabs
-syn keyword     sqfCommand      loadbackpack loadfile loadgame loadidentity
-syn keyword     sqfCommand      loadmagazine loadoverlay loadstatus
-syn keyword     sqfCommand      loaduniform loadvest local localize
-syn keyword     sqfCommand      locationposition lock lockcamerato lockcargo
-syn keyword     sqfCommand      lockdriver locked lockedcargo lockeddriver
-syn keyword     sqfCommand      lockedturret lockidentity lockturret lockwp
-syn keyword     sqfCommand      log logentities lognetwork lognetworkterminate
-syn keyword     sqfCommand      lookat lookatpos magazinecargo magazines
-syn keyword     sqfCommand      magazinesallturrets magazinesammo
-syn keyword     sqfCommand      magazinesammocargo magazinesammofull
-syn keyword     sqfCommand      magazinesdetail magazinesdetailbackpack
-syn keyword     sqfCommand      magazinesdetailuniform magazinesdetailvest
-syn keyword     sqfCommand      magazinesturret magazineturretammo mapanimadd
-syn keyword     sqfCommand      mapanimclear mapanimcommit mapanimdone
-syn keyword     sqfCommand      mapcenteroncamera mapgridposition
-syn keyword     sqfCommand      markasfinishedonsteam markeralpha markerbrush
-syn keyword     sqfCommand      markercolor markerdir markerpos markershape
-syn keyword     sqfCommand      markersize markertext markertype max members
-syn keyword     sqfCommand      menuaction menuadd menuchecked menuclear
-syn keyword     sqfCommand      menucollapse menudata menudelete menuenable
-syn keyword     sqfCommand      menuenabled menuexpand menuhover menupicture
-syn keyword     sqfCommand      menusetaction menusetcheck menusetdata
-syn keyword     sqfCommand      menusetpicture menusetvalue menushortcut
-syn keyword     sqfCommand      menushortcuttext menusize menusort menutext
-syn keyword     sqfCommand      menuurl menuvalue min mineactive
-syn keyword     sqfCommand      minedetectedby missionconfigfile
-syn keyword     sqfCommand      missiondifficulty missionname missionnamespace
-syn keyword     sqfCommand      missionstart missionversion mod modeltoworld
-syn keyword     sqfCommand      modeltoworldvisual modeltoworldvisualworld
-syn keyword     sqfCommand      modeltoworldworld modparams moonintensity
-syn keyword     sqfCommand      moonphase morale move move3dencamera moveinany
-syn keyword     sqfCommand      moveincargo moveincommander moveindriver
-syn keyword     sqfCommand      moveingunner moveinturret moveobjecttoend
-syn keyword     sqfCommand      moveout movetime moveto movetocompleted
-syn keyword     sqfCommand      movetofailed musicvolume name namesound
-syn keyword     sqfCommand      nearentities nearestbuilding nearestlocation
-syn keyword     sqfCommand      nearestlocations nearestlocationwithdubbing
-syn keyword     sqfCommand      nearestobject nearestobjects
-syn keyword     sqfCommand      nearestterrainobjects nearobjects
-syn keyword     sqfCommand      nearobjectsready nearroads nearsupplies
-syn keyword     sqfCommand      neartargets needreload netid newoverlay
-syn keyword     sqfCommand      nextmenuitemindex nextweatherchange nmenuitems
-syn keyword     sqfCommand      not numberofenginesrtd numbertodate
-syn keyword     sqfCommand      objectcurators objectfromnetid objectparent
-syn keyword     sqfCommand      objstatus onbriefinggroup onbriefingnotes
-syn keyword     sqfCommand      onbriefingplan onbriefingteamswitch
-syn keyword     sqfCommand      oncommandmodechanged ondoubleclick oneachframe
-syn keyword     sqfCommand      ongroupiconclick ongroupiconoverenter
-syn keyword     sqfCommand      ongroupiconoverleave onhcgroupselectionchanged
-syn keyword     sqfCommand      onmapsingleclick onplayerconnected
-syn keyword     sqfCommand      onplayerdisconnected onpreloadfinished
-syn keyword     sqfCommand      onpreloadstarted onshownewobject onteamswitch
-syn keyword     sqfCommand      opencuratorinterface opendlcpage openmap
-syn keyword     sqfCommand      opensteamapp openyoutubevideo opfor or
-syn keyword     sqfCommand      ordergetin overcast overcastforecast owner
-syn keyword     sqfCommand      param params parsenumber parsesimplearray
-syn keyword     sqfCommand      parsetext parsingnamespace particlesquality pi
-syn keyword     sqfCommand      pickweaponpool pitch pixelgrid pixelgridbase
-syn keyword     sqfCommand      pixelgridnouiscale pixelh pixelw
-syn keyword     sqfCommand      playableslotsnumber playableunits playaction
-syn keyword     sqfCommand      playactionnow player playerrespawntime
-syn keyword     sqfCommand      playerside playersnumber playgesture
-syn keyword     sqfCommand      playmission playmove playmovenow playmusic
-syn keyword     sqfCommand      playscriptedmission playsound playsound3d
-syn keyword     sqfCommand      position positioncameratoworld
-syn keyword     sqfCommand      posscreentoworld posworldtoscreen
-syn keyword     sqfCommand      ppeffectadjust ppeffectcommit
-syn keyword     sqfCommand      ppeffectcommitted ppeffectcreate
-syn keyword     sqfCommand      ppeffectdestroy ppeffectenable ppeffectenabled
-syn keyword     sqfCommand      ppeffectforceinnvg precision preloadcamera
-syn keyword     sqfCommand      preloadobject preloadsound preloadtitleobj
-syn keyword     sqfCommand      preloadtitlersc primaryweapon
-syn keyword     sqfCommand      primaryweaponitems primaryweaponmagazine
-syn keyword     sqfCommand      priority private processdiarylink
-syn keyword     sqfCommand      productversion profilename profilenamespace
-syn keyword     sqfCommand      profilenamesteam progressloadingscreen
-syn keyword     sqfCommand      progressposition progresssetposition
-syn keyword     sqfCommand      publicvariable publicvariableclient
-syn keyword     sqfCommand      publicvariableserver pushback pushbackunique
-syn keyword     sqfCommand      putweaponpool queryitemspool querymagazinepool
-syn keyword     sqfCommand      queryweaponpool rad radiochanneladd
-syn keyword     sqfCommand      radiochannelcreate radiochannelremove
-syn keyword     sqfCommand      radiochannelsetcallsign radiochannelsetlabel
-syn keyword     sqfCommand      radiovolume rain rainbow random rank rankid
-syn keyword     sqfCommand      rating rectangular registeredtasks
-syn keyword     sqfCommand      registertask reload reloadenabled
-syn keyword     sqfCommand      remotecontrol remoteexec remoteexeccall
-syn keyword     sqfCommand      remoteexecutedowner remove3denconnection
-syn keyword     sqfCommand      remove3deneventhandler remove3denlayer
-syn keyword     sqfCommand      removeaction removeall3deneventhandlers
-syn keyword     sqfCommand      removeallactions removeallassigneditems
-syn keyword     sqfCommand      removeallcontainers removeallcuratoraddons
-syn keyword     sqfCommand      removeallcuratorcameraareas
-syn keyword     sqfCommand      removeallcuratoreditingareas
-syn keyword     sqfCommand      removealleventhandlers removeallhandgunitems
-syn keyword     sqfCommand      removeallitems removeallitemswithmagazines
-syn keyword     sqfCommand      removeallmissioneventhandlers
-syn keyword     sqfCommand      removeallmpeventhandlers
-syn keyword     sqfCommand      removeallmusiceventhandlers
-syn keyword     sqfCommand      removeallownedmines
-syn keyword     sqfCommand      removeallprimaryweaponitems removeallweapons
-syn keyword     sqfCommand      removebackpack removebackpackglobal
-syn keyword     sqfCommand      removecuratoraddons removecuratorcameraarea
-syn keyword     sqfCommand      removecuratoreditableobjects
-syn keyword     sqfCommand      removecuratoreditingarea removedrawicon
-syn keyword     sqfCommand      removedrawlinks removeeventhandler
-syn keyword     sqfCommand      removefromremainscollector removegoggles
-syn keyword     sqfCommand      removegroupicon removehandgunitem
-syn keyword     sqfCommand      removeheadgear removeitem
-syn keyword     sqfCommand      removeitemfrombackpack removeitemfromuniform
-syn keyword     sqfCommand      removeitemfromvest removeitems removemagazine
-syn keyword     sqfCommand      removemagazineglobal removemagazines
-syn keyword     sqfCommand      removemagazinesturret removemagazineturret
-syn keyword     sqfCommand      removemenuitem removemissioneventhandler
-syn keyword     sqfCommand      removempeventhandler removemusiceventhandler
-syn keyword     sqfCommand      removeownedmine removeprimaryweaponitem
-syn keyword     sqfCommand      removesecondaryweaponitem removesimpletask
-syn keyword     sqfCommand      removeswitchableunit removeteammember
-syn keyword     sqfCommand      removeuniform removevest removeweapon
-syn keyword     sqfCommand      removeweaponattachmentcargo removeweaponcargo
-syn keyword     sqfCommand      removeweaponglobal removeweaponturret
-syn keyword     sqfCommand      reportremotetarget requiredversion
-syn keyword     sqfCommand      resetcamshake resetsubgroupdirection resize
-syn keyword     sqfCommand      resources respawnvehicle restarteditorcamera
-syn keyword     sqfCommand      reveal revealmine reverse reversedmousey
-syn keyword     sqfCommand      roadat roadsconnectedto roledescription
-syn keyword     sqfCommand      ropeattachedobjects ropeattachedto
-syn keyword     sqfCommand      ropeattachenabled ropeattachto ropecreate
-syn keyword     sqfCommand      ropecut ropedestroy ropedetach ropeendposition
-syn keyword     sqfCommand      ropelength ropes ropeunwind ropeunwound
-syn keyword     sqfCommand      rotorsforcesrtd rotorsrpmrtd round
-syn keyword     sqfCommand      runinitscript safezoneh safezonew safezonewabs
-syn keyword     sqfCommand      safezonex safezonexabs safezoney
-syn keyword     sqfCommand      save3deninventory savegame saveidentity
-syn keyword     sqfCommand      savejoysticks saveoverlay saveprofilenamespace
-syn keyword     sqfCommand      savestatus savevar savingenabled say say2d
-syn keyword     sqfCommand      say3d scopename score scoreside screenshot
-syn keyword     sqfCommand      screentoworld scriptname scudstate
-syn keyword     sqfCommand      secondaryweapon secondaryweaponitems
-syn keyword     sqfCommand      secondaryweaponmagazine select
-syn keyword     sqfCommand      selectbestplaces selectdiarysubject
-syn keyword     sqfCommand      selectededitorobjects selecteditorobject
-syn keyword     sqfCommand      selectionnames selectionposition selectleader
-syn keyword     sqfCommand      selectmax selectmin selectnoplayer
-syn keyword     sqfCommand      selectplayer selectrandom selectrandomweighted
-syn keyword     sqfCommand      selectweapon selectweaponturret sendaumessage
-syn keyword     sqfCommand      sendsimplecommand sendtask sendtaskresult
-syn keyword     sqfCommand      sendudpmessage servercommand
-syn keyword     sqfCommand      servercommandavailable servercommandexecutable
-syn keyword     sqfCommand      servername servertime set set3denattribute
-syn keyword     sqfCommand      set3denattributes set3dengrid
-syn keyword     sqfCommand      set3deniconsvisible set3denlayer
-syn keyword     sqfCommand      set3denlinesvisible set3denlogictype
-syn keyword     sqfCommand      set3denmissionattribute
-syn keyword     sqfCommand      set3denmissionattributes set3denmodelsvisible
-syn keyword     sqfCommand      set3denobjecttype set3denselected setacctime
-syn keyword     sqfCommand      setactualcollectivertd setairplanethrottle
-syn keyword     sqfCommand      setairportside setammo setammocargo
-syn keyword     sqfCommand      setammoonpylon setanimspeedcoef setaperture
-syn keyword     sqfCommand      setaperturenew setarmorypoints setattributes
-syn keyword     sqfCommand      setautonomous setbehaviour
-syn keyword     sqfCommand      setbleedingremaining setbrakesrtd
-syn keyword     sqfCommand      setcamerainterest setcamshakedefparams
-syn keyword     sqfCommand      setcamshakeparams setcamuseti setcaptive
-syn keyword     sqfCommand      setcenterofmass setcollisionlight
-syn keyword     sqfCommand      setcombatmode setcompassoscillation
-syn keyword     sqfCommand      setconvoyseparation
-syn keyword     sqfCommand      setcuratorcameraareaceiling setcuratorcoef
-syn keyword     sqfCommand      setcuratoreditingareatype
-syn keyword     sqfCommand      setcuratorwaypointcost setcurrentchannel
-syn keyword     sqfCommand      setcurrenttask setcurrentwaypoint
-syn keyword     sqfCommand      setcustomaimcoef setcustommissiondata
-syn keyword     sqfCommand      setcustomsoundcontroller setcustomweightrtd
-syn keyword     sqfCommand      setdamage setdammage setdate setdebriefingtext
-syn keyword     sqfCommand      setdefaultcamera setdestination
-syn keyword     sqfCommand      setdetailmapblendpars setdir setdirection
-syn keyword     sqfCommand      setdrawicon setdriveonpath setdropinterval
-syn keyword     sqfCommand      setdynamicsimulationdistance
-syn keyword     sqfCommand      setdynamicsimulationdistancecoef seteditormode
-syn keyword     sqfCommand      seteditorobjectscope seteffectcondition
-syn keyword     sqfCommand      setenginerpmrtd setface setfaceanimation
-syn keyword     sqfCommand      setfatigue setfeaturetype
-syn keyword     sqfCommand      setflaganimationphase setflagowner setflagside
-syn keyword     sqfCommand      setflagtexture setfog setforcegeneratorrtd
-syn keyword     sqfCommand      setformation setformationtask setformdir
-syn keyword     sqfCommand      setfriend setfromeditor setfsmvariable setfuel
-syn keyword     sqfCommand      setfuelcargo setgroupicon setgroupiconparams
-syn keyword     sqfCommand      setgroupiconsselectable setgroupiconsvisible
-syn keyword     sqfCommand      setgroupid setgroupidglobal setgroupowner
-syn keyword     sqfCommand      setgusts sethidebehind sethit sethitindex
-syn keyword     sqfCommand      sethitpointdamage sethorizonparallaxcoef
-syn keyword     sqfCommand      sethudmovementlevels setidentity setimportance
-syn keyword     sqfCommand      setinfopanel setleader setlightambient
-syn keyword     sqfCommand      setlightattenuation setlightbrightness
-syn keyword     sqfCommand      setlightcolor setlightdaylight
-syn keyword     sqfCommand      setlightflaremaxdistance setlightflaresize
-syn keyword     sqfCommand      setlightintensity setlightnings
-syn keyword     sqfCommand      setlightuseflare setlocalwindparams
-syn keyword     sqfCommand      setmagazineturretammo setmarkeralpha
-syn keyword     sqfCommand      setmarkeralphalocal setmarkerbrush
-syn keyword     sqfCommand      setmarkerbrushlocal setmarkercolor
-syn keyword     sqfCommand      setmarkercolorlocal setmarkerdir
-syn keyword     sqfCommand      setmarkerdirlocal setmarkerpos
-syn keyword     sqfCommand      setmarkerposlocal setmarkershape
-syn keyword     sqfCommand      setmarkershapelocal setmarkersize
-syn keyword     sqfCommand      setmarkersizelocal setmarkertext
-syn keyword     sqfCommand      setmarkertextlocal setmarkertype
-syn keyword     sqfCommand      setmarkertypelocal setmass setmimic
-syn keyword     sqfCommand      setmouseposition setmusiceffect
-syn keyword     sqfCommand      setmusiceventhandler setname setnamesound
-syn keyword     sqfCommand      setobjectarguments setobjectmaterial
-syn keyword     sqfCommand      setobjectmaterialglobal setobjectproxy
-syn keyword     sqfCommand      setobjecttexture setobjecttextureglobal
-syn keyword     sqfCommand      setobjectviewdistance setovercast setowner
-syn keyword     sqfCommand      setoxygenremaining setparticlecircle
-syn keyword     sqfCommand      setparticleclass setparticlefire
-syn keyword     sqfCommand      setparticleparams setparticlerandom
-syn keyword     sqfCommand      setpilotcameradirection setpilotcamerarotation
-syn keyword     sqfCommand      setpilotcameratarget setpilotlight
-syn keyword     sqfCommand      setpipeffect setpitch setplatenumber
-syn keyword     sqfCommand      setplayable setplayerrespawntime setpos
-syn keyword     sqfCommand      setposasl setposasl2 setposaslw setposatl
-syn keyword     sqfCommand      setposition setposworld setpylonloadout
-syn keyword     sqfCommand      setpylonspriority setradiomsg setrain
-syn keyword     sqfCommand      setrainbow setrandomlip setrank setrectangular
-syn keyword     sqfCommand      setrepaircargo setrotorbrakertd
-syn keyword     sqfCommand      setshadowdistance setshotparents setside
-syn keyword     sqfCommand      setsimpletaskalwaysvisible
-syn keyword     sqfCommand      setsimpletaskcustomdata
-syn keyword     sqfCommand      setsimpletaskdescription
-syn keyword     sqfCommand      setsimpletaskdestination setsimpletasktarget
-syn keyword     sqfCommand      setsimpletasktype setsimulweatherlayers
-syn keyword     sqfCommand      setsize setskill setslingload setsoundeffect
-syn keyword     sqfCommand      setspeaker setspeech setspeedmode setstamina
-syn keyword     sqfCommand      setstaminascheme setstatvalue setsuppression
-syn keyword     sqfCommand      setsystemofunits settargetage
-syn keyword     sqfCommand      settaskmarkeroffset settaskresult settaskstate
-syn keyword     sqfCommand      setterraingrid settext settimemultiplier
-syn keyword     sqfCommand      settitleeffect settrafficdensity
-syn keyword     sqfCommand      settrafficdistance settrafficgap
-syn keyword     sqfCommand      settrafficspeed settriggeractivation
-syn keyword     sqfCommand      settriggerarea settriggerstatements
-syn keyword     sqfCommand      settriggertext settriggertimeout
-syn keyword     sqfCommand      settriggertype settype setunconscious
-syn keyword     sqfCommand      setunitability setunitloadout setunitpos
-syn keyword     sqfCommand      setunitposweak setunitrank
-syn keyword     sqfCommand      setunitrecoilcoefficient setunittrait
-syn keyword     sqfCommand      setunloadincombat setuseractiontext
-syn keyword     sqfCommand      setusermfdtext setusermfdvalue setvariable
-syn keyword     sqfCommand      setvectordir setvectordirandup setvectorup
-syn keyword     sqfCommand      setvehicleammo setvehicleammodef
-syn keyword     sqfCommand      setvehiclearmor setvehiclecargo setvehicleid
-syn keyword     sqfCommand      setvehiclelock setvehicleposition
-syn keyword     sqfCommand      setvehicleradar setvehiclereceiveremotetargets
-syn keyword     sqfCommand      setvehiclereportownposition
-syn keyword     sqfCommand      setvehiclereportremotetargets setvehicletipars
-syn keyword     sqfCommand      setvehiclevarname setvelocity
-syn keyword     sqfCommand      setvelocitymodelspace
-syn keyword     sqfCommand      setvelocitytransformation setviewdistance
-syn keyword     sqfCommand      setvisibleiftreecollapsed setwantedrpmrtd
-syn keyword     sqfCommand      setwaves setwaypointbehaviour
-syn keyword     sqfCommand      setwaypointcombatmode
-syn keyword     sqfCommand      setwaypointcompletionradius
-syn keyword     sqfCommand      setwaypointdescription
-syn keyword     sqfCommand      setwaypointforcebehaviour setwaypointformation
-syn keyword     sqfCommand      setwaypointhouseposition
-syn keyword     sqfCommand      setwaypointloiterradius setwaypointloitertype
-syn keyword     sqfCommand      setwaypointname setwaypointposition
-syn keyword     sqfCommand      setwaypointscript setwaypointspeed
-syn keyword     sqfCommand      setwaypointstatements setwaypointtimeout
-syn keyword     sqfCommand      setwaypointtype setwaypointvisible
-syn keyword     sqfCommand      setweaponreloadingtime setwind setwinddir
-syn keyword     sqfCommand      setwindforce setwindstr setwingforcescalertd
-syn keyword     sqfCommand      setwppos show3dicons showchat showcinemaborder
-syn keyword     sqfCommand      showcommandingmenu showcompass
-syn keyword     sqfCommand      showcuratorcompass showgps showhud showlegend
-syn keyword     sqfCommand      showmap shownartillerycomputer shownchat
-syn keyword     sqfCommand      showncompass showncuratorcompass
-syn keyword     sqfCommand      showneweditorobject showngps shownhud shownmap
-syn keyword     sqfCommand      shownpad shownradio shownscoretable
-syn keyword     sqfCommand      shownuavfeed shownwarrant shownwatch showpad
-syn keyword     sqfCommand      showradio showscoretable showsubtitles
-syn keyword     sqfCommand      showuavfeed showwarrant showwatch showwaypoint
-syn keyword     sqfCommand      showwaypoints side sideambientlife sidechat
-syn keyword     sqfCommand      sideempty sideenemy sidefriendly sidelogic
-syn keyword     sqfCommand      sideradio simpletasks simulationenabled
-syn keyword     sqfCommand      simulclouddensity simulcloudocclusion
-syn keyword     sqfCommand      simulinclouds simulweathersync sin size sizeof
-syn keyword     sqfCommand      skill skillfinal skiptime sliderposition
-syn keyword     sqfCommand      sliderrange slidersetposition slidersetrange
-syn keyword     sqfCommand      slidersetspeed sliderspeed
-syn keyword     sqfCommand      slingloadassistantshown soldiermagazines
-syn keyword     sqfCommand      someammo sort soundvolume speaker speed
-syn keyword     sqfCommand      speedmode splitstring sqrt squadparams stance
-syn keyword     sqfCommand      startloadingscreen step stop stopenginertd
-syn keyword     sqfCommand      stopped str sunormoon supportinfo suppressfor
-syn keyword     sqfCommand      surfaceiswater surfacenormal surfacetype
-syn keyword     sqfCommand      swimindepth switchableunits switchaction
-syn keyword     sqfCommand      switchcamera switchgesture switchlight
-syn keyword     sqfCommand      switchmove synchronizedobjects
-syn keyword     sqfCommand      synchronizedtriggers synchronizedwaypoints
-syn keyword     sqfCommand      synchronizeobjectsadd synchronizeobjectsremove
-syn keyword     sqfCommand      synchronizetrigger synchronizewaypoint
-syn keyword     sqfCommand      systemchat systemofunits tan targetknowledge
-syn keyword     sqfCommand      targets targetsaggregate targetsquery
-syn keyword     sqfCommand      taskalwaysvisible taskchildren taskcompleted
-syn keyword     sqfCommand      taskcustomdata taskdescription taskdestination
-syn keyword     sqfCommand      taskhint taskmarkeroffset taskparent
-syn keyword     sqfCommand      taskresult taskstate tasktype teammember
-syn keyword     sqfCommand      teamname teams teamswitch teamswitchenabled
-syn keyword     sqfCommand      teamtype terrainintersect terrainintersectasl
-syn keyword     sqfCommand      terrainintersectatasl text textlog
-syn keyword     sqfCommand      textlogformat tg time timemultiplier titlecut
-syn keyword     sqfCommand      titlefadeout titleobj titlersc titletext
-syn keyword     sqfCommand      toarray tofixed tolower tostring toupper
-syn keyword     sqfCommand      triggeractivated triggeractivation triggerarea
-syn keyword     sqfCommand      triggerattachedvehicle triggerattachobject
-syn keyword     sqfCommand      triggerattachvehicle triggerdynamicsimulation
-syn keyword     sqfCommand      triggerstatements triggertext triggertimeout
-syn keyword     sqfCommand      triggertimeoutcurrent triggertype turretlocal
-syn keyword     sqfCommand      turretowner turretunit tvadd tvclear
-syn keyword     sqfCommand      tvcollapse tvcollapseall tvcount tvcursel
-syn keyword     sqfCommand      tvdata tvdelete tvexpand tvexpandall tvpicture
-syn keyword     sqfCommand      tvpictureright tvsetcolor tvsetcursel
-syn keyword     sqfCommand      tvsetdata tvsetpicture tvsetpicturecolor
-syn keyword     sqfCommand      tvsetpicturecolordisabled
-syn keyword     sqfCommand      tvsetpicturecolorselected tvsetpictureright
-syn keyword     sqfCommand      tvsetpicturerightcolor
-syn keyword     sqfCommand      tvsetpicturerightcolordisabled
-syn keyword     sqfCommand      tvsetpicturerightcolorselected
-syn keyword     sqfCommand      tvsetselectcolor tvsettext tvsettooltip
-syn keyword     sqfCommand      tvsetvalue tvsort tvsortbyvalue tvtext
-syn keyword     sqfCommand      tvtooltip tvvalue type typename typeof
-syn keyword     sqfCommand      uavcontrol uinamespace uisleep unassigncurator
-syn keyword     sqfCommand      unassignitem unassignteam unassignvehicle
-syn keyword     sqfCommand      underwater uniform uniformcontainer
-syn keyword     sqfCommand      uniformitems uniformmagazines unitaddons
-syn keyword     sqfCommand      unitaimposition unitaimpositionvisual
-syn keyword     sqfCommand      unitbackpack unitisuav unitpos unitready
-syn keyword     sqfCommand      unitrecoilcoefficient units unitsbelowheight
-syn keyword     sqfCommand      unlinkitem unlockachievement unregistertask
-syn keyword     sqfCommand      updatedrawicon updatemenuitem updateobjecttree
-syn keyword     sqfCommand      useaiopermapobstructiontest
-syn keyword     sqfCommand      useaisteeringcomponent useaudiotimeformoves
-syn keyword     sqfCommand      userinputdisabled vectoradd vectorcos
-syn keyword     sqfCommand      vectorcrossproduct vectordiff vectordir
-syn keyword     sqfCommand      vectordirvisual vectordistance
-syn keyword     sqfCommand      vectordistancesqr vectordotproduct
-syn keyword     sqfCommand      vectorfromto vectormagnitude
-syn keyword     sqfCommand      vectormagnitudesqr vectormodeltoworld
-syn keyword     sqfCommand      vectormodeltoworldvisual vectormultiply
-syn keyword     sqfCommand      vectornormalized vectorup vectorupvisual
-syn keyword     sqfCommand      vectorworldtomodel vectorworldtomodelvisual
-syn keyword     sqfCommand      vehicle vehiclecargoenabled vehiclechat
-syn keyword     sqfCommand      vehicleradio vehiclereceiveremotetargets
-syn keyword     sqfCommand      vehiclereportownposition
-syn keyword     sqfCommand      vehiclereportremotetargets vehicles
-syn keyword     sqfCommand      vehiclevarname velocity velocitymodelspace
-syn keyword     sqfCommand      verifysignature vest vestcontainer vestitems
-syn keyword     sqfCommand      vestmagazines viewdistance visiblecompass
-syn keyword     sqfCommand      visiblegps visiblemap visibleposition
-syn keyword     sqfCommand      visiblepositionasl visiblescoretable
-syn keyword     sqfCommand      visiblewatch waves waypointattachedobject
-syn keyword     sqfCommand      waypointattachedvehicle waypointattachobject
-syn keyword     sqfCommand      waypointattachvehicle waypointbehaviour
-syn keyword     sqfCommand      waypointcombatmode waypointcompletionradius
-syn keyword     sqfCommand      waypointdescription waypointforcebehaviour
-syn keyword     sqfCommand      waypointformation waypointhouseposition
-syn keyword     sqfCommand      waypointloiterradius waypointloitertype
-syn keyword     sqfCommand      waypointname waypointposition waypoints
-syn keyword     sqfCommand      waypointscript waypointsenableduav
-syn keyword     sqfCommand      waypointshow waypointspeed waypointstatements
-syn keyword     sqfCommand      waypointtimeout waypointtimeoutcurrent
-syn keyword     sqfCommand      waypointtype waypointvisible weaponaccessories
-syn keyword     sqfCommand      weaponaccessoriescargo weaponcargo
-syn keyword     sqfCommand      weapondirection weaponinertia weaponlowered
-syn keyword     sqfCommand      weapons weaponsitems weaponsitemscargo
-syn keyword     sqfCommand      weaponstate weaponsturret weightrtd wfsidetext
-syn keyword     sqfCommand      wind winddir windrtd windstr wingsforcesrtd
-syn keyword     sqfCommand      worldname worldsize worldtomodel
+syn keyword     sqfCommand      # abs acctime acos action actionids actionkeys actionkeysimages actionkeysnames
+syn keyword     sqfCommand      actionkeysnamesarray actionname actionparams activateaddons activatedaddons activatekey
+syn keyword     sqfCommand      add3denconnection add3deneventhandler add3denlayer addaction addbackpack
+syn keyword     sqfCommand      addbackpackcargo addbackpackcargoglobal addbackpackglobal addcamshake addcuratoraddons
+syn keyword     sqfCommand      addcuratorcameraarea addcuratoreditableobjects addcuratoreditingarea addcuratorpoints
+syn keyword     sqfCommand      addeditorobject addeventhandler addforce addforcegeneratorrtd addgoggles addgroupicon
+syn keyword     sqfCommand      addhandgunitem addheadgear additem additemcargo additemcargoglobal additempool
+syn keyword     sqfCommand      additemtobackpack additemtouniform additemtovest addlivestats addmagazine
+syn keyword     sqfCommand      addmagazineammocargo addmagazinecargo addmagazinecargoglobal addmagazineglobal
+syn keyword     sqfCommand      addmagazinepool addmagazines addmagazineturret addmenu addmenuitem
+syn keyword     sqfCommand      addmissioneventhandler addmpeventhandler addmusiceventhandler addownedmine
+syn keyword     sqfCommand      addplayerscores addprimaryweaponitem addpublicvariableeventhandler addrating
+syn keyword     sqfCommand      addresources addscore addscoreside addsecondaryweaponitem addswitchableunit
+syn keyword     sqfCommand      addteammember addtoremainscollector addtorque adduniform addvehicle addvest addwaypoint
+syn keyword     sqfCommand      addweapon addweaponcargo addweaponcargoglobal addweaponglobal addweaponitem
+syn keyword     sqfCommand      addweaponpool addweaponturret addweaponwithattachmentscargo
+syn keyword     sqfCommand      addweaponwithattachmentscargoglobal admin agent agents agltoasl aimedattarget aimpos
+syn keyword     sqfCommand      airdensitycurvertd airdensityrtd airplanethrottle airportside aisfinishheal alive
+syn keyword     sqfCommand      all3denentities allairports allcontrols allcurators allcutlayers alldead alldeadmen
+syn keyword     sqfCommand      alldisplays allgroups allmapmarkers allmines allmissionobjects allow3dmode
+syn keyword     sqfCommand      allowcrewinimmobile allowcuratorlogicignoreareas allowdamage allowdammage
+syn keyword     sqfCommand      allowfileoperations allowfleeing allowgetin allowsprint allplayers allsimpleobjects
+syn keyword     sqfCommand      allsites allturrets allunits allunitsuav allvariables ammo ammoonpylon and animate
+syn keyword     sqfCommand      animatebay animatedoor animatepylon animatesource animationnames animationphase
+syn keyword     sqfCommand      animationsourcephase animationstate append apply armorypoints arrayintersect asin
+syn keyword     sqfCommand      asltoagl asltoatl assert assignascargo assignascargoindex assignascommander
+syn keyword     sqfCommand      assignasdriver assignasgunner assignasturret assigncurator assignedcargo
+syn keyword     sqfCommand      assignedcommander assigneddriver assignedgunner assigneditems assignedtarget
+syn keyword     sqfCommand      assignedteam assignedvehicle assignedvehiclerole assignitem assignteam assigntoairport
+syn keyword     sqfCommand      atan atan2 atg atltoasl attachedobject attachedobjects attachedto attachobject attachto
+syn keyword     sqfCommand      attackenabled backpack backpackcargo backpackcontainer backpackitems backpackmagazines
+syn keyword     sqfCommand      backpackspacefor behaviour benchmark bezierinterpolation binocular blufor boundingbox
+syn keyword     sqfCommand      boundingboxreal boundingcenter breakout breakto briefingname buildingexit buildingpos
+syn keyword     sqfCommand      buldozer_enableroaddiag buldozer_isenabledroaddiag buldozer_loadnewroads
+syn keyword     sqfCommand      buldozer_reloadopermap buttonaction buttonsetaction cadetmode calculatepath
+syn keyword     sqfCommand      calculateplayervisibilitybyfriendly camcommand camcommit camcommitprepared camcommitted
+syn keyword     sqfCommand      camconstuctionsetparams camcreate camdestroy cameraeffect cameraeffectenablehud
+syn keyword     sqfCommand      camerainterest cameraon cameraview campaignconfigfile campreload campreloaded
+syn keyword     sqfCommand      campreparebank campreparedir campreparedive campreparefocus campreparefov
+syn keyword     sqfCommand      campreparefovrange campreparepos campreparerelpos campreparetarget camsetbank camsetdir
+syn keyword     sqfCommand      camsetdive camsetfocus camsetfov camsetfovrange camsetpos camsetrelpos camsettarget
+syn keyword     sqfCommand      camtarget camusenvg canadd canadditemtobackpack canadditemtouniform canadditemtovest
+syn keyword     sqfCommand      cancelsimpletaskdestination canfire canmove canslingload canstand cansuspend
+syn keyword     sqfCommand      cantriggerdynamicsimulation canunloadincombat canvehiclecargo captive captivenum
+syn keyword     sqfCommand      cbchecked cbsetchecked ceil channelenabled cheatsenabled checkaifeature checkvisibility
+syn keyword     sqfCommand      classname clear3denattribute clear3deninventory clearallitemsfrombackpack
+syn keyword     sqfCommand      clearbackpackcargo clearbackpackcargoglobal clearforcesrtd cleargroupicons
+syn keyword     sqfCommand      clearitemcargo clearitemcargoglobal clearitempool clearmagazinecargo
+syn keyword     sqfCommand      clearmagazinecargoglobal clearmagazinepool clearoverlay clearradio clearweaponcargo
+syn keyword     sqfCommand      clearweaponcargoglobal clearweaponpool clientowner closedialog closedisplay closeoverlay
+syn keyword     sqfCommand      collapseobjecttree collect3denhistory collectivertd combatmode commandartilleryfire
+syn keyword     sqfCommand      commandchat commander commandfire commandfollow commandgetout commandingmenu commandmove
+syn keyword     sqfCommand      commandradio commandstop commandsuppressivefire commandtarget commandwatch comment
+syn keyword     sqfCommand      commitoverlay completedfsm composetext configclasses configfile confighierarchy
+syn keyword     sqfCommand      configname confignull configproperties configsourceaddonlist configsourcemod
+syn keyword     sqfCommand      configsourcemodlist confirmsensortarget connectterminaltouav controlsgroupctrl
+syn keyword     sqfCommand      copyfromclipboard copytoclipboard copywaypoints cos countenemy countfriendly countside
+syn keyword     sqfCommand      counttype countunknown create3dencomposition create3denentity createagent createcenter
+syn keyword     sqfCommand      createdialog creatediarylink creatediaryrecord creatediarysubject createdisplay
+syn keyword     sqfCommand      creategeardialog creategroup createguardedpoint createlocation createmarker
+syn keyword     sqfCommand      createmarkerlocal createmenu createmine createmissiondisplay creatempcampaigndisplay
+syn keyword     sqfCommand      createsimpleobject createsimpletask createsite createsoundsource createtask createteam
+syn keyword     sqfCommand      createtrigger createunit createvehicle createvehiclecrew createvehiclelocal crew
+syn keyword     sqfCommand      ctaddheader ctaddrow ctclear ctcursel ctdata ctfindheaderrows ctfindrowheader
+syn keyword     sqfCommand      ctheadercontrols ctheadercount ctremoveheaders ctremoverows ctrlactivate
+syn keyword     sqfCommand      ctrladdeventhandler ctrlangle ctrlanimatemodel ctrlanimationphasemodel
+syn keyword     sqfCommand      ctrlautoscrolldelay ctrlautoscrollrewind ctrlautoscrollspeed ctrlchecked ctrlclassname
+syn keyword     sqfCommand      ctrlcommit ctrlcommitted ctrlcreate ctrldelete ctrlenable ctrlenabled ctrlfade
+syn keyword     sqfCommand      ctrlhtmlloaded ctrlidc ctrlidd ctrlmapanimadd ctrlmapanimclear ctrlmapanimcommit
+syn keyword     sqfCommand      ctrlmapanimdone ctrlmapcursor ctrlmapmouseover ctrlmapscale ctrlmapscreentoworld
+syn keyword     sqfCommand      ctrlmapworldtoscreen ctrlmodel ctrlmodeldirandup ctrlmodelscale ctrlparent
+syn keyword     sqfCommand      ctrlparentcontrolsgroup ctrlposition ctrlremovealleventhandlers ctrlremoveeventhandler
+syn keyword     sqfCommand      ctrlscale ctrlsetactivecolor ctrlsetangle ctrlsetautoscrolldelay ctrlsetautoscrollrewind
+syn keyword     sqfCommand      ctrlsetautoscrollspeed ctrlsetbackgroundcolor ctrlsetchecked ctrlsetdisabledcolor
+syn keyword     sqfCommand      ctrlseteventhandler ctrlsetfade ctrlsetfocus ctrlsetfont ctrlsetfonth1 ctrlsetfonth1b
+syn keyword     sqfCommand      ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3 ctrlsetfonth3b ctrlsetfonth4 ctrlsetfonth4b
+syn keyword     sqfCommand      ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6 ctrlsetfonth6b ctrlsetfontheight
+syn keyword     sqfCommand      ctrlsetfontheighth1 ctrlsetfontheighth2 ctrlsetfontheighth3 ctrlsetfontheighth4
+syn keyword     sqfCommand      ctrlsetfontheighth5 ctrlsetfontheighth6 ctrlsetfontheightsecondary ctrlsetfontp
+syn keyword     sqfCommand      ctrlsetfontpb ctrlsetfontsecondary ctrlsetforegroundcolor ctrlsetmodel
+syn keyword     sqfCommand      ctrlsetmodeldirandup ctrlsetmodelscale ctrlsetpixelprecision ctrlsetposition
+syn keyword     sqfCommand      ctrlsetpositionh ctrlsetpositionw ctrlsetpositionx ctrlsetpositiony ctrlsetscale
+syn keyword     sqfCommand      ctrlsetstructuredtext ctrlsettext ctrlsettextcolor ctrlsettextcolorsecondary
+syn keyword     sqfCommand      ctrlsettextsecondary ctrlsettooltip ctrlsettooltipcolorbox ctrlsettooltipcolorshade
+syn keyword     sqfCommand      ctrlsettooltipcolortext ctrlshow ctrlshown ctrltext ctrltextheight ctrltextsecondary
+syn keyword     sqfCommand      ctrltextwidth ctrltype ctrlvisible ctrowcontrols ctrowcount ctsetcursel ctsetdata
+syn keyword     sqfCommand      ctsetheadertemplate ctsetrowtemplate ctsetvalue ctvalue curatoraddons curatorcamera
+syn keyword     sqfCommand      curatorcameraarea curatorcameraareaceiling curatorcoef curatoreditableobjects
+syn keyword     sqfCommand      curatoreditingarea curatoreditingareatype curatormouseover curatorpoints
+syn keyword     sqfCommand      curatorregisteredobjects curatorselected curatorwaypointcost current3denoperation
+syn keyword     sqfCommand      currentchannel currentcommand currentmagazine currentmagazinedetail
+syn keyword     sqfCommand      currentmagazinedetailturret currentmagazineturret currentmuzzle currentnamespace
+syn keyword     sqfCommand      currenttask currenttasks currentthrowable currentvisionmode currentwaypoint
+syn keyword     sqfCommand      currentweapon currentweaponmode currentweaponturret currentzeroing cursorobject
+syn keyword     sqfCommand      cursortarget customchat customradio customwaypointposition cutfadeout cutobj cutrsc
+syn keyword     sqfCommand      cuttext damage date datetonumber daytime deactivatekey debriefingtext debugfsm debuglog
+syn keyword     sqfCommand      decaygraphvalues deg delete3denentities deleteat deletecenter deletecollection
+syn keyword     sqfCommand      deleteeditorobject deletegroup deletegroupwhenempty deleteidentity deletelocation
+syn keyword     sqfCommand      deletemarker deletemarkerlocal deleterange deleteresources deletesite deletestatus
+syn keyword     sqfCommand      deleteteam deletevehicle deletevehiclecrew deletewaypoint detach detectedmines
+syn keyword     sqfCommand      diag_activemissionfsms diag_activescripts diag_activesqfscripts diag_activesqsscripts
+syn keyword     sqfCommand      diag_codeperformance diag_dynamicsimulationend diag_fps diag_fpsmin diag_frameno
+syn keyword     sqfCommand      diag_lightnewload diag_log diag_setlightnew diag_ticktime dialog diarysubjectexists
+syn keyword     sqfCommand      didjip didjipowner difficulty difficultyenabled difficultyenabledrtd difficultyoption
+syn keyword     sqfCommand      direction directsay disableai disablecollisionwith disableconversation
+syn keyword     sqfCommand      disabledebriefingstats disablemapindicators disablenvgequipment disableremotesensors
+syn keyword     sqfCommand      disableserialization disabletiequipment disableuavconnectability disableuserinput
+syn keyword     sqfCommand      displayaddeventhandler displayctrl displayparent displayremovealleventhandlers
+syn keyword     sqfCommand      displayremoveeventhandler displayseteventhandler dissolveteam distance distance2d
+syn keyword     sqfCommand      distancesqr distributionregion do3denaction doartilleryfire dofire dofollow dogetout
+syn keyword     sqfCommand      domove doorphase dostop dosuppressivefire dotarget dowatch drawarrow drawellipse
+syn keyword     sqfCommand      drawicon drawicon3d drawline drawline3d drawlink drawlocation drawpolygon drawrectangle
+syn keyword     sqfCommand      drawtriangle driver drop dynamicsimulationdistance dynamicsimulationdistancecoef
+syn keyword     sqfCommand      dynamicsimulationenabled dynamicsimulationsystemenabled echo edit3denmissionattributes
+syn keyword     sqfCommand      editobject editorseteventhandler effectivecommander emptypositions enableai
+syn keyword     sqfCommand      enableaifeature enableaimprecision enableattack enableaudiofeature enableautostartuprtd
+syn keyword     sqfCommand      enableautotrimrtd enablecamshake enablecaustics enablechannel enablecollisionwith
+syn keyword     sqfCommand      enablecopilot enabledebriefingstats enablediaglegend enabledynamicsimulation
+syn keyword     sqfCommand      enabledynamicsimulationsystem enableenddialog enableengineartillery enableenvironment
+syn keyword     sqfCommand      enablefatigue enablegunlights enableinfopanelcomponent enableirlasers enablemimics
+syn keyword     sqfCommand      enablepersonturret enableradio enablereload enableropeattach enablesatnormalondetail
+syn keyword     sqfCommand      enablesaving enablesentences enablesimulation enablesimulationglobal enablestamina
+syn keyword     sqfCommand      enablestressdamage enableteamswitch enabletraffic enableuavconnectability
+syn keyword     sqfCommand      enableuavwaypoints enablevehiclecargo enablevehiclesensor enableweapondisassembly endl
+syn keyword     sqfCommand      endloadingscreen endmission engineon enginesisonrtd enginespowerrtd enginesrpmrtd
+syn keyword     sqfCommand      enginestorquertd entities environmentenabled estimatedendservertime estimatedtimeleft
+syn keyword     sqfCommand      evalobjectargument everybackpack everycontainer exec execeditorscript exit exp
+syn keyword     sqfCommand      expecteddestination exportjipmessages eyedirection eyepos face faction fademusic
+syn keyword     sqfCommand      faderadio fadesound fadespeech failmission fillweaponsfrompool find findcover
+syn keyword     sqfCommand      finddisplay findeditorobject findemptyposition findemptypositionready findif
+syn keyword     sqfCommand      findnearestenemy finishmissioninit finite fire fireattarget firstbackpack flag
+syn keyword     sqfCommand      flaganimationphase flagowner flagside flagtexture fleeing floor flyinheight
+syn keyword     sqfCommand      flyinheightasl fog fogforecast fogparams forceadduniform forceatpositionrtd forcedmap
+syn keyword     sqfCommand      forceend forceflagtexture forcefollowroad forcegeneratorrtd forcemap forcerespawn
+syn keyword     sqfCommand      forcespeed forcewalk forceweaponfire forceweatherchange foreachmember foreachmemberagent
+syn keyword     sqfCommand      foreachmemberteam forgettarget format formation formationdirection formationleader
+syn keyword     sqfCommand      formationmembers formationposition formationtask formattext formleader freelook
+syn keyword     sqfCommand      fromeditor fuel fullcrew gearidcammocount gearslotammocount gearslotdata
+syn keyword     sqfCommand      get3denactionstate get3denattribute get3dencamera get3denconnections get3denentity
+syn keyword     sqfCommand      get3denentityid get3dengrid get3deniconsvisible get3denlayerentities get3denlinesvisible
+syn keyword     sqfCommand      get3denmissionattribute get3denmouseover get3denselected getaimingcoef
+syn keyword     sqfCommand      getallenvsoundcontrollers getallhitpointsdamage getallownedmines getallsoundcontrollers
+syn keyword     sqfCommand      getammocargo getanimaimprecision getanimspeedcoef getarray getartilleryammo
+syn keyword     sqfCommand      getartillerycomputersettings getartilleryeta getassignedcuratorlogic
+syn keyword     sqfCommand      getassignedcuratorunit getaudiooptionvolumes getbackpackcargo getbleedingremaining
+syn keyword     sqfCommand      getburningvalue getcalculateplayervisibilitybyfriendly getcameraviewdirection
+syn keyword     sqfCommand      getcargoindex getcenterofmass getclientstate getclientstatenumber
+syn keyword     sqfCommand      getcompatiblepylonmagazines getconnecteduav getcontainermaxload getcursorobjectparams
+syn keyword     sqfCommand      getcustomaimcoef getcustomsoundcontroller getcustomsoundcontrollercount getdammage
+syn keyword     sqfCommand      getdescription getdir getdirvisual getdlcassetsusage getdlcassetsusagebyname getdlcs
+syn keyword     sqfCommand      getdlcusagetime geteditorcamera geteditormode geteditorobjectscope getelevationoffset
+syn keyword     sqfCommand      getenginetargetrpmrtd getenvsoundcontroller getfatigue getfieldmanualstartpage
+syn keyword     sqfCommand      getforcedflagtexture getfriend getfsmvariable getfuelcargo getgraphvalues getgroupicon
+syn keyword     sqfCommand      getgroupiconparams getgroupicons gethidefrom gethit gethitindex gethitpointdamage
+syn keyword     sqfCommand      getitemcargo getmagazinecargo getmarkercolor getmarkerpos getmarkersize getmarkertype
+syn keyword     sqfCommand      getmass getmissionconfig getmissionconfigvalue getmissiondlcs getmissionlayerentities
+syn keyword     sqfCommand      getmissionlayers getmodelinfo getmouseposition getmusicplayedtime getnumber
+syn keyword     sqfCommand      getobjectargument getobjectchildren getobjectdlc getobjectmaterials getobjectproxy
+syn keyword     sqfCommand      getobjecttextures getobjecttype getobjectviewdistance getoxygenremaining
+syn keyword     sqfCommand      getpersonuseddlcs getpilotcameradirection getpilotcameraposition getpilotcamerarotation
+syn keyword     sqfCommand      getpilotcameratarget getplatenumber getplayerchannel getplayerscores getplayeruid getpos
+syn keyword     sqfCommand      getposasl getposaslvisual getposaslw getposatl getposatlvisual getposvisual getposworld
+syn keyword     sqfCommand      getpylonmagazines getreldir getrelpos getremotesensorsdisabled getrepaircargo
+syn keyword     sqfCommand      getresolution getrotorbrakertd getshadowdistance getshotparents getslingload
+syn keyword     sqfCommand      getsoundcontroller getsoundcontrollerresult getspeed getstamina getstatvalue
+syn keyword     sqfCommand      getsubtitleoptions getsuppression getterraingrid getterrainheightasl gettext
+syn keyword     sqfCommand      gettotaldlcusagetime gettrimoffsetrtd getunitloadout getunittrait getusermfdtext
+syn keyword     sqfCommand      getusermfdvalue getvariable getvehiclecargo getweaponcargo getweaponsway
+syn keyword     sqfCommand      getwingsorientationrtd getwingspositionrtd getwppos glanceat globalchat globalradio
+syn keyword     sqfCommand      goggles goto group groupchat groupfromnetid groupiconselectable groupiconsvisible
+syn keyword     sqfCommand      groupid groupowner groupradio groupselectedunits groupselectunit gunner gusts halt
+syn keyword     sqfCommand      handgunitems handgunmagazine handgunweapon handshit hasinterface haspilotcamera
+syn keyword     sqfCommand      hasweapon hcallgroups hcgroupparams hcleader hcremoveallgroups hcremovegroup hcselected
+syn keyword     sqfCommand      hcselectgroup hcsetgroup hcshowbar hcshownbar headgear hidebody hideobject
+syn keyword     sqfCommand      hideobjectglobal hideselection hint hintc hintcadet hintsilent hmd hostmission htmlload
+syn keyword     sqfCommand      hudmovementlevels humidity image importallgroups importance in inarea inareaarray
+syn keyword     sqfCommand      incapacitatedstate inflame inflamed infopanel infopanelcomponentenabled
+syn keyword     sqfCommand      infopanelcomponents infopanels ingameuiseteventhandler inheritsfrom initambientlife
+syn keyword     sqfCommand      inpolygon inputaction inrangeofartillery inserteditorobject intersect is3den
+syn keyword     sqfCommand      is3denmultiplayer isabletobreathe isagent isaimprecisionenabled isarray isautohoveron
+syn keyword     sqfCommand      isautonomous isautostartupenabledrtd isautotest isautotrimonrtd isbleeding isburning
+syn keyword     sqfCommand      isclass iscollisionlighton iscopilotenabled isdamageallowed isdedicated isdlcavailable
+syn keyword     sqfCommand      isengineon isequalto isequaltype isequaltypeall isequaltypeany isequaltypearray
+syn keyword     sqfCommand      isequaltypeparams isfilepatchingenabled isflashlighton isflatempty isforcedwalk
+syn keyword     sqfCommand      isformationleader isgroupdeletedwhenempty ishidden isinremainscollector
+syn keyword     sqfCommand      isinstructorfigureenabled isirlaseron iskeyactive iskindof islaseron islighton
+syn keyword     sqfCommand      islocalized ismanualfire ismarkedforcollection ismultiplayer ismultiplayersolo isnil
+syn keyword     sqfCommand      isnull isnumber isobjecthidden isobjectrtd isonroad ispipenabled isplayer isrealtime
+syn keyword     sqfCommand      isremoteexecuted isremoteexecutedjip issensortargetconfirmed isserver isshowing3dicons
+syn keyword     sqfCommand      issimpleobject issprintallowed isstaminaenabled issteammission isstreamfriendlyuienabled
+syn keyword     sqfCommand      isstressdamageenabled istext istouchingground isturnedout istuthintsenabled
+syn keyword     sqfCommand      isuavconnectable isuavconnected isuicontext isuniformallowed isvehiclecargo
+syn keyword     sqfCommand      isvehicleradaron isvehiclesensorenabled iswalking isweapondeployed isweaponrested
+syn keyword     sqfCommand      itemcargo items itemswithmagazines join joinas joinassilent joinsilent joinstring
+syn keyword     sqfCommand      kbadddatabase kbadddatabasetargets kbaddtopic kbhastopic kbreact kbremovetopic kbtell
+syn keyword     sqfCommand      kbwassaid keyimage keyname knowsabout land landat landresult language lasertarget lbadd
+syn keyword     sqfCommand      lbclear lbcolor lbcolorright lbcursel lbdata lbdelete lbisselected lbpicture
+syn keyword     sqfCommand      lbpictureright lbselection lbsetcolor lbsetcolorright lbsetcursel lbsetdata lbsetpicture
+syn keyword     sqfCommand      lbsetpicturecolor lbsetpicturecolordisabled lbsetpicturecolorselected lbsetpictureright
+syn keyword     sqfCommand      lbsetpicturerightcolor lbsetpicturerightcolordisabled lbsetpicturerightcolorselected
+syn keyword     sqfCommand      lbsetselectcolor lbsetselectcolorright lbsetselected lbsettext lbsettextright
+syn keyword     sqfCommand      lbsettooltip lbsetvalue lbsize lbsort lbsortbyvalue lbtext lbtextright lbvalue leader
+syn keyword     sqfCommand      leaderboarddeinit leaderboardgetrows leaderboardinit leaderboardrequestrowsfriends
+syn keyword     sqfCommand      leaderboardrequestrowsglobal leaderboardrequestrowsglobalarounduser
+syn keyword     sqfCommand      leaderboardsrequestuploadscore leaderboardsrequestuploadscorekeepbest leaderboardstate
+syn keyword     sqfCommand      leavevehicle librarycredits librarydisclaimers lifestate lightattachobject
+syn keyword     sqfCommand      lightdetachobject lightison lightnings limitspeed linearconversion linebreak
+syn keyword     sqfCommand      lineintersects lineintersectsobjs lineintersectssurfaces lineintersectswith linkitem
+syn keyword     sqfCommand      list listobjects listremotetargets listvehiclesensors ln lnbaddarray lnbaddcolumn
+syn keyword     sqfCommand      lnbaddrow lnbclear lnbcolor lnbcolorright lnbcurselrow lnbdata lnbdeletecolumn
+syn keyword     sqfCommand      lnbdeleterow lnbgetcolumnsposition lnbpicture lnbpictureright lnbsetcolor
+syn keyword     sqfCommand      lnbsetcolorright lnbsetcolumnspos lnbsetcurselrow lnbsetdata lnbsetpicture
+syn keyword     sqfCommand      lnbsetpicturecolor lnbsetpicturecolorright lnbsetpicturecolorselected
+syn keyword     sqfCommand      lnbsetpicturecolorselectedright lnbsetpictureright lnbsettext lnbsettextright
+syn keyword     sqfCommand      lnbsettooltip lnbsetvalue lnbsize lnbsort lnbsortbyvalue lnbtext lnbtextright lnbvalue
+syn keyword     sqfCommand      load loadabs loadbackpack loadfile loadgame loadidentity loadmagazine loadoverlay
+syn keyword     sqfCommand      loadstatus loaduniform loadvest local localize locationposition lock lockcamerato
+syn keyword     sqfCommand      lockcargo lockdriver locked lockedcargo lockeddriver lockedturret lockidentity
+syn keyword     sqfCommand      lockturret lockwp log logentities lognetwork lognetworkterminate lookat lookatpos
+syn keyword     sqfCommand      magazinecargo magazines magazinesallturrets magazinesammo magazinesammocargo
+syn keyword     sqfCommand      magazinesammofull magazinesdetail magazinesdetailbackpack magazinesdetailuniform
+syn keyword     sqfCommand      magazinesdetailvest magazinesturret magazineturretammo mapanimadd mapanimclear
+syn keyword     sqfCommand      mapanimcommit mapanimdone mapcenteroncamera mapgridposition markasfinishedonsteam
+syn keyword     sqfCommand      markeralpha markerbrush markercolor markerdir markerpos markershape markersize
+syn keyword     sqfCommand      markertext markertype matrixmultiply matrixtranspose max members menuaction menuadd
+syn keyword     sqfCommand      menuchecked menuclear menucollapse menudata menudelete menuenable menuenabled menuexpand
+syn keyword     sqfCommand      menuhover menupicture menusetaction menusetcheck menusetdata menusetpicture menusetvalue
+syn keyword     sqfCommand      menushortcut menushortcuttext menusize menusort menutext menuurl menuvalue min
+syn keyword     sqfCommand      mineactive minedetectedby missiletarget missiletargetpos missionconfigfile
+syn keyword     sqfCommand      missiondifficulty missionname missionnamespace missionstart missionversion mod
+syn keyword     sqfCommand      modeltoworld modeltoworldvisual modeltoworldvisualworld modeltoworldworld modparams
+syn keyword     sqfCommand      moonintensity moonphase morale move move3dencamera moveinany moveincargo moveincommander
+syn keyword     sqfCommand      moveindriver moveingunner moveinturret moveobjecttoend moveout movetime moveto
+syn keyword     sqfCommand      movetocompleted movetofailed musicvolume name namesound nearentities nearestbuilding
+syn keyword     sqfCommand      nearestlocation nearestlocations nearestlocationwithdubbing nearestobject nearestobjects
+syn keyword     sqfCommand      nearestterrainobjects nearobjects nearobjectsready nearroads nearsupplies neartargets
+syn keyword     sqfCommand      needreload netid newoverlay nextmenuitemindex nextweatherchange nmenuitems not
+syn keyword     sqfCommand      numberofenginesrtd numbertodate objectcurators objectfromnetid objectparent objstatus
+syn keyword     sqfCommand      onbriefinggroup onbriefingnotes onbriefingplan onbriefingteamswitch oncommandmodechanged
+syn keyword     sqfCommand      ondoubleclick oneachframe ongroupiconclick ongroupiconoverenter ongroupiconoverleave
+syn keyword     sqfCommand      onhcgroupselectionchanged onmapsingleclick onplayerconnected onplayerdisconnected
+syn keyword     sqfCommand      onpreloadfinished onpreloadstarted onshownewobject onteamswitch opencuratorinterface
+syn keyword     sqfCommand      opendlcpage openmap opensteamapp openyoutubevideo opfor or ordergetin overcast
+syn keyword     sqfCommand      overcastforecast owner param params parsenumber parsesimplearray parsetext
+syn keyword     sqfCommand      parsingnamespace particlesquality pi pickweaponpool pitch pixelgrid pixelgridbase
+syn keyword     sqfCommand      pixelgridnouiscale pixelh pixelw playableslotsnumber playableunits playaction
+syn keyword     sqfCommand      playactionnow player playerrespawntime playerside playersnumber playgesture playmission
+syn keyword     sqfCommand      playmove playmovenow playmusic playscriptedmission playsound playsound3d position
+syn keyword     sqfCommand      positioncameratoworld posscreentoworld posworldtoscreen ppeffectadjust ppeffectcommit
+syn keyword     sqfCommand      ppeffectcommitted ppeffectcreate ppeffectdestroy ppeffectenable ppeffectenabled
+syn keyword     sqfCommand      ppeffectforceinnvg precision preloadcamera preloadobject preloadsound preloadtitleobj
+syn keyword     sqfCommand      preloadtitlersc primaryweapon primaryweaponitems primaryweaponmagazine priority
+syn keyword     sqfCommand      processdiarylink productversion profilename profilenamespace profilenamesteam
+syn keyword     sqfCommand      progressloadingscreen progressposition progresssetposition publicvariable
+syn keyword     sqfCommand      publicvariableclient publicvariableserver pushback pushbackunique putweaponpool
+syn keyword     sqfCommand      queryitemspool querymagazinepool queryweaponpool rad radiochanneladd radiochannelcreate
+syn keyword     sqfCommand      radiochannelremove radiochannelsetcallsign radiochannelsetlabel radiovolume rain rainbow
+syn keyword     sqfCommand      random rank rankid rating rectangular registeredtasks registertask reload reloadenabled
+syn keyword     sqfCommand      remotecontrol remoteexec remoteexeccall remoteexecutedowner remove3denconnection
+syn keyword     sqfCommand      remove3deneventhandler remove3denlayer removeaction removeall3deneventhandlers
+syn keyword     sqfCommand      removeallactions removeallassigneditems removeallcontainers removeallcuratoraddons
+syn keyword     sqfCommand      removeallcuratorcameraareas removeallcuratoreditingareas removealleventhandlers
+syn keyword     sqfCommand      removeallhandgunitems removeallitems removeallitemswithmagazines
+syn keyword     sqfCommand      removeallmissioneventhandlers removeallmpeventhandlers removeallmusiceventhandlers
+syn keyword     sqfCommand      removeallownedmines removeallprimaryweaponitems removeallweapons removebackpack
+syn keyword     sqfCommand      removebackpackglobal removecuratoraddons removecuratorcameraarea
+syn keyword     sqfCommand      removecuratoreditableobjects removecuratoreditingarea removedrawicon removedrawlinks
+syn keyword     sqfCommand      removeeventhandler removefromremainscollector removegoggles removegroupicon
+syn keyword     sqfCommand      removehandgunitem removeheadgear removeitem removeitemfrombackpack removeitemfromuniform
+syn keyword     sqfCommand      removeitemfromvest removeitems removemagazine removemagazineglobal removemagazines
+syn keyword     sqfCommand      removemagazinesturret removemagazineturret removemenuitem removemissioneventhandler
+syn keyword     sqfCommand      removempeventhandler removemusiceventhandler removeownedmine removeprimaryweaponitem
+syn keyword     sqfCommand      removesecondaryweaponitem removesimpletask removeswitchableunit removeteammember
+syn keyword     sqfCommand      removeuniform removevest removeweapon removeweaponattachmentcargo removeweaponcargo
+syn keyword     sqfCommand      removeweaponglobal removeweaponturret reportremotetarget requiredversion resetcamshake
+syn keyword     sqfCommand      resetsubgroupdirection resize resources respawnvehicle restarteditorcamera reveal
+syn keyword     sqfCommand      revealmine reverse reversedmousey roadat roadsconnectedto roledescription
+syn keyword     sqfCommand      ropeattachedobjects ropeattachedto ropeattachenabled ropeattachto ropecreate ropecut
+syn keyword     sqfCommand      ropedestroy ropedetach ropeendposition ropelength ropes ropeunwind ropeunwound
+syn keyword     sqfCommand      rotorsforcesrtd rotorsrpmrtd round runinitscript safezoneh safezonew safezonewabs
+syn keyword     sqfCommand      safezonex safezonexabs safezoney save3deninventory savegame saveidentity savejoysticks
+syn keyword     sqfCommand      saveoverlay saveprofilenamespace savestatus savevar savingenabled say say2d say3d
+syn keyword     sqfCommand      scopename score scoreside screenshot screentoworld scriptname scudstate secondaryweapon
+syn keyword     sqfCommand      secondaryweaponitems secondaryweaponmagazine select selectbestplaces selectdiarysubject
+syn keyword     sqfCommand      selectededitorobjects selecteditorobject selectionnames selectionposition selectleader
+syn keyword     sqfCommand      selectmax selectmin selectnoplayer selectplayer selectrandom selectrandomweighted
+syn keyword     sqfCommand      selectweapon selectweaponturret sendaumessage sendsimplecommand sendtask sendtaskresult
+syn keyword     sqfCommand      sendudpmessage servercommand servercommandavailable servercommandexecutable servername
+syn keyword     sqfCommand      servertime set set3denattribute set3denattributes set3dengrid set3deniconsvisible
+syn keyword     sqfCommand      set3denlayer set3denlinesvisible set3denlogictype set3denmissionattribute
+syn keyword     sqfCommand      set3denmissionattributes set3denmodelsvisible set3denobjecttype set3denselected
+syn keyword     sqfCommand      setacctime setactualcollectivertd setairplanethrottle setairportside setammo
+syn keyword     sqfCommand      setammocargo setammoonpylon setanimspeedcoef setaperture setaperturenew setarmorypoints
+syn keyword     sqfCommand      setattributes setautonomous setbehaviour setbehaviourstrong setbleedingremaining
+syn keyword     sqfCommand      setbrakesrtd setcamerainterest setcamshakedefparams setcamshakeparams setcamuseti
+syn keyword     sqfCommand      setcaptive setcenterofmass setcollisionlight setcombatmode setcompassoscillation
+syn keyword     sqfCommand      setconvoyseparation setcuratorcameraareaceiling setcuratorcoef setcuratoreditingareatype
+syn keyword     sqfCommand      setcuratorwaypointcost setcurrentchannel setcurrenttask setcurrentwaypoint
+syn keyword     sqfCommand      setcustomaimcoef setcustommissiondata setcustomsoundcontroller setcustomweightrtd
+syn keyword     sqfCommand      setdamage setdammage setdate setdebriefingtext setdefaultcamera setdestination
+syn keyword     sqfCommand      setdetailmapblendpars setdir setdirection setdrawicon setdriveonpath setdropinterval
+syn keyword     sqfCommand      setdynamicsimulationdistance setdynamicsimulationdistancecoef seteditormode
+syn keyword     sqfCommand      seteditorobjectscope seteffectcondition setenginerpmrtd setface setfaceanimation
+syn keyword     sqfCommand      setfatigue setfeaturetype setflaganimationphase setflagowner setflagside setflagtexture
+syn keyword     sqfCommand      setfog setforcegeneratorrtd setformation setformationtask setformdir setfriend
+syn keyword     sqfCommand      setfromeditor setfsmvariable setfuel setfuelcargo setgroupicon setgroupiconparams
+syn keyword     sqfCommand      setgroupiconsselectable setgroupiconsvisible setgroupid setgroupidglobal setgroupowner
+syn keyword     sqfCommand      setgusts sethidebehind sethit sethitindex sethitpointdamage sethorizonparallaxcoef
+syn keyword     sqfCommand      sethudmovementlevels setidentity setimportance setinfopanel setleader setlightambient
+syn keyword     sqfCommand      setlightattenuation setlightbrightness setlightcolor setlightdaylight
+syn keyword     sqfCommand      setlightflaremaxdistance setlightflaresize setlightintensity setlightnings
+syn keyword     sqfCommand      setlightuseflare setlocalwindparams setmagazineturretammo setmarkeralpha
+syn keyword     sqfCommand      setmarkeralphalocal setmarkerbrush setmarkerbrushlocal setmarkercolor
+syn keyword     sqfCommand      setmarkercolorlocal setmarkerdir setmarkerdirlocal setmarkerpos setmarkerposlocal
+syn keyword     sqfCommand      setmarkershape setmarkershapelocal setmarkersize setmarkersizelocal setmarkertext
+syn keyword     sqfCommand      setmarkertextlocal setmarkertype setmarkertypelocal setmass setmimic setmissiletarget
+syn keyword     sqfCommand      setmissiletargetpos setmouseposition setmusiceffect setmusiceventhandler setname
+syn keyword     sqfCommand      setnamesound setobjectarguments setobjectmaterial setobjectmaterialglobal setobjectproxy
+syn keyword     sqfCommand      setobjecttexture setobjecttextureglobal setobjectviewdistance setovercast setowner
+syn keyword     sqfCommand      setoxygenremaining setparticlecircle setparticleclass setparticlefire setparticleparams
+syn keyword     sqfCommand      setparticlerandom setpilotcameradirection setpilotcamerarotation setpilotcameratarget
+syn keyword     sqfCommand      setpilotlight setpipeffect setpitch setplatenumber setplayable setplayerrespawntime
+syn keyword     sqfCommand      setpos setposasl setposasl2 setposaslw setposatl setposition setposworld setpylonloadout
+syn keyword     sqfCommand      setpylonspriority setradiomsg setrain setrainbow setrandomlip setrank setrectangular
+syn keyword     sqfCommand      setrepaircargo setrotorbrakertd setshadowdistance setshotparents setside
+syn keyword     sqfCommand      setsimpletaskalwaysvisible setsimpletaskcustomdata setsimpletaskdescription
+syn keyword     sqfCommand      setsimpletaskdestination setsimpletasktarget setsimpletasktype setsimulweatherlayers
+syn keyword     sqfCommand      setsize setskill setslingload setsoundeffect setspeaker setspeech setspeedmode
+syn keyword     sqfCommand      setstamina setstaminascheme setstatvalue setsuppression setsystemofunits settargetage
+syn keyword     sqfCommand      settaskmarkeroffset settaskresult settaskstate setterraingrid settext settimemultiplier
+syn keyword     sqfCommand      settitleeffect settrafficdensity settrafficdistance settrafficgap settrafficspeed
+syn keyword     sqfCommand      settriggeractivation settriggerarea settriggerstatements settriggertext
+syn keyword     sqfCommand      settriggertimeout settriggertype settype setunconscious setunitability setunitloadout
+syn keyword     sqfCommand      setunitpos setunitposweak setunitrank setunitrecoilcoefficient setunittrait
+syn keyword     sqfCommand      setunloadincombat setuseractiontext setusermfdtext setusermfdvalue setvariable
+syn keyword     sqfCommand      setvectordir setvectordirandup setvectorup setvehicleammo setvehicleammodef
+syn keyword     sqfCommand      setvehiclearmor setvehiclecargo setvehicleid setvehiclelock setvehicleposition
+syn keyword     sqfCommand      setvehicleradar setvehiclereceiveremotetargets setvehiclereportownposition
+syn keyword     sqfCommand      setvehiclereportremotetargets setvehicletipars setvehiclevarname setvelocity
+syn keyword     sqfCommand      setvelocitymodelspace setvelocitytransformation setviewdistance
+syn keyword     sqfCommand      setvisibleiftreecollapsed setwantedrpmrtd setwaves setwaypointbehaviour
+syn keyword     sqfCommand      setwaypointcombatmode setwaypointcompletionradius setwaypointdescription
+syn keyword     sqfCommand      setwaypointforcebehaviour setwaypointformation setwaypointhouseposition
+syn keyword     sqfCommand      setwaypointloiterradius setwaypointloitertype setwaypointname setwaypointposition
+syn keyword     sqfCommand      setwaypointscript setwaypointspeed setwaypointstatements setwaypointtimeout
+syn keyword     sqfCommand      setwaypointtype setwaypointvisible setweaponreloadingtime setwind setwinddir
+syn keyword     sqfCommand      setwindforce setwindstr setwingforcescalertd setwppos show3dicons showchat
+syn keyword     sqfCommand      showcinemaborder showcommandingmenu showcompass showcuratorcompass showgps showhud
+syn keyword     sqfCommand      showlegend showmap shownartillerycomputer shownchat showncompass showncuratorcompass
+syn keyword     sqfCommand      showneweditorobject showngps shownhud shownmap shownpad shownradio shownscoretable
+syn keyword     sqfCommand      shownuavfeed shownwarrant shownwatch showpad showradio showscoretable showsubtitles
+syn keyword     sqfCommand      showuavfeed showwarrant showwatch showwaypoint showwaypoints side sideambientlife
+syn keyword     sqfCommand      sidechat sideempty sideenemy sidefriendly sidelogic sideradio simpletasks
+syn keyword     sqfCommand      simulationenabled simulclouddensity simulcloudocclusion simulinclouds simulweathersync
+syn keyword     sqfCommand      sin size sizeof skill skillfinal skiptime sliderposition sliderrange slidersetposition
+syn keyword     sqfCommand      slidersetrange slidersetspeed sliderspeed slingloadassistantshown soldiermagazines
+syn keyword     sqfCommand      someammo sort soundvolume speaker speed speedmode splitstring sqrt squadparams stance
+syn keyword     sqfCommand      startloadingscreen step stop stopenginertd stopped str sunormoon supportinfo suppressfor
+syn keyword     sqfCommand      surfaceiswater surfacenormal surfacetype swimindepth switchableunits switchaction
+syn keyword     sqfCommand      switchcamera switchgesture switchlight switchmove synchronizedobjects
+syn keyword     sqfCommand      synchronizedtriggers synchronizedwaypoints synchronizeobjectsadd
+syn keyword     sqfCommand      synchronizeobjectsremove synchronizetrigger synchronizewaypoint systemchat systemofunits
+syn keyword     sqfCommand      tan targetknowledge targets targetsaggregate targetsquery taskalwaysvisible taskchildren
+syn keyword     sqfCommand      taskcompleted taskcustomdata taskdescription taskdestination taskhint taskmarkeroffset
+syn keyword     sqfCommand      taskparent taskresult taskstate tasktype teammember teamname teams teamswitch
+syn keyword     sqfCommand      teamswitchenabled teamtype terrainintersect terrainintersectasl terrainintersectatasl
+syn keyword     sqfCommand      text textlog textlogformat tg time timemultiplier titlecut titlefadeout titleobj
+syn keyword     sqfCommand      titlersc titletext toarray tofixed tolower tostring toupper triggeractivated
+syn keyword     sqfCommand      triggeractivation triggerammo triggerarea triggerattachedvehicle triggerattachobject
+syn keyword     sqfCommand      triggerattachvehicle triggerdynamicsimulation triggerstatements triggertext
+syn keyword     sqfCommand      triggertimeout triggertimeoutcurrent triggertype turretlocal turretowner turretunit
+syn keyword     sqfCommand      tvadd tvclear tvcollapse tvcollapseall tvcount tvcursel tvdata tvdelete tvexpand
+syn keyword     sqfCommand      tvexpandall tvpicture tvpictureright tvsetcolor tvsetcursel tvsetdata tvsetpicture
+syn keyword     sqfCommand      tvsetpicturecolor tvsetpicturecolordisabled tvsetpicturecolorselected tvsetpictureright
+syn keyword     sqfCommand      tvsetpicturerightcolor tvsetpicturerightcolordisabled tvsetpicturerightcolorselected
+syn keyword     sqfCommand      tvsetselectcolor tvsettext tvsettooltip tvsetvalue tvsort tvsortbyvalue tvtext tvtooltip
+syn keyword     sqfCommand      tvvalue type typename typeof uavcontrol uinamespace uisleep unassigncurator unassignitem
+syn keyword     sqfCommand      unassignteam unassignvehicle underwater uniform uniformcontainer uniformitems
+syn keyword     sqfCommand      uniformmagazines unitaddons unitaimposition unitaimpositionvisual unitbackpack unitisuav
+syn keyword     sqfCommand      unitpos unitready unitrecoilcoefficient units unitsbelowheight unlinkitem
+syn keyword     sqfCommand      unlockachievement unregistertask updatedrawicon updatemenuitem updateobjecttree
+syn keyword     sqfCommand      useaiopermapobstructiontest useaisteeringcomponent useaudiotimeformoves
+syn keyword     sqfCommand      userinputdisabled vectoradd vectorcos vectorcrossproduct vectordiff vectordir
+syn keyword     sqfCommand      vectordirvisual vectordistance vectordistancesqr vectordotproduct vectorfromto
+syn keyword     sqfCommand      vectorlinearconversion vectormagnitude vectormagnitudesqr vectormodeltoworld
+syn keyword     sqfCommand      vectormodeltoworldvisual vectormultiply vectornormalized vectorup vectorupvisual
+syn keyword     sqfCommand      vectorworldtomodel vectorworldtomodelvisual vehicle vehiclecargoenabled vehiclechat
+syn keyword     sqfCommand      vehicleradio vehiclereceiveremotetargets vehiclereportownposition
+syn keyword     sqfCommand      vehiclereportremotetargets vehicles vehiclevarname velocity velocitymodelspace
+syn keyword     sqfCommand      verifysignature vest vestcontainer vestitems vestmagazines viewdistance visiblecompass
+syn keyword     sqfCommand      visiblegps visiblemap visibleposition visiblepositionasl visiblescoretable visiblewatch
+syn keyword     sqfCommand      waves waypointattachedobject waypointattachedvehicle waypointattachobject
+syn keyword     sqfCommand      waypointattachvehicle waypointbehaviour waypointcombatmode waypointcompletionradius
+syn keyword     sqfCommand      waypointdescription waypointforcebehaviour waypointformation waypointhouseposition
+syn keyword     sqfCommand      waypointloiterradius waypointloitertype waypointname waypointposition waypoints
+syn keyword     sqfCommand      waypointscript waypointsenableduav waypointshow waypointspeed waypointstatements
+syn keyword     sqfCommand      waypointtimeout waypointtimeoutcurrent waypointtype waypointvisible weaponaccessories
+syn keyword     sqfCommand      weaponaccessoriescargo weaponcargo weapondirection weaponinertia weaponlowered weapons
+syn keyword     sqfCommand      weaponsitems weaponsitemscargo weaponstate weaponsturret weightrtd wfsidetext wind
+syn keyword     sqfCommand      winddir windrtd windstr wingsforcesrtd worldname worldsize worldtomodel
 syn keyword     sqfCommand      worldtomodelvisual worldtoscreen
 
 syn keyword     sqfRepeat       do for foreach from to while
 
-syn keyword     sqfKeyword      call callextension execfsm execvm exitwith
-syn keyword     sqfKeyword      scriptdone sleep spawn terminate waituntil
+syn keyword     sqfKeyword      call callextension execfsm execvm exitwith private scriptdone sleep spawn terminate
+syn keyword     sqfKeyword      waituntil
 
-syn keyword     sqfStatement    commandfsm compile compilefinal count dofsm
-syn keyword     sqfStatement    preprocessfile preprocessfilelinenumbers
+syn keyword     sqfStatement    commandfsm compile compilefinal count dofsm preprocessfile preprocessfilelinenumbers
 
 syn keyword     sqfConditional  case default else if switch then
 
-syn keyword     sqfConstant     civilian controlnull displaynull east grpnull
-syn keyword     sqfConstant     independent locationnull netobjnull nil
-syn keyword     sqfConstant     objnull resistance scriptnull sideunknown
-syn keyword     sqfConstant     tasknull teammembernull west
+syn keyword     sqfConstant     civilian controlnull displaynull east grpnull independent locationnull netobjnull nil
+syn keyword     sqfConstant     objnull resistance scriptnull sideunknown tasknull teammembernull west
 
 syn keyword     sqfBoolean      false no true yes
 
-syn keyword     sqfOperator     ! != # % && * + - / : < <= == > >= >> \|| ^
+syn keyword     sqfOperator     ! != % && * + - / : < <= == > >= >> \|| ^
 
 syn keyword     sqfExceptional  catch throw try
 
@@ -866,8 +448,6 @@ syn region      sqfDefine       start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip
 syn match       sqfNumber       display "\<\d\+\>"
 
 syn region      sqfLocalVar     display start="\<_\w" end="\>"
-
-syn match       sqfFunction     display "\<\w\+fnc\w\+\>"
 
 let b:current_syntax = "sqf"
 

--- a/syntax/sqf.vim
+++ b/syntax/sqf.vim
@@ -466,7 +466,7 @@ hi def link sqfBraces       sqfDelimiter
 hi def link sqfDelimiter    Delimiter
 
 " START HI GEN
-hi def link sqfCommand      Special
+hi def link sqfCommand      Function
 hi def link sqfKeyword      Keyword
 hi def link sqfRepeat       Repeat
 hi def link sqfConditional  Conditional

--- a/syntax/sqf.vim
+++ b/syntax/sqf.vim
@@ -2,7 +2,7 @@
 " Language:     SQF Script (used in Bohemia Interactives ArmA/ArmA2/etc.)
 " Maintainers:  sqwishy, Jonpas
 " Author:       shreds-of-sanity@gmx.net
-" Version:      2019-08-08 [Arma 3 v1.94]
+" Version:      2021-10-10 [Arma 3 v2.06]
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -16,34 +16,36 @@ syn case ignore
 syn keyword sqfCommand      abs acctime acos action actionids actionkeys actionkeysimages actionkeysnames
 syn keyword sqfCommand      actionkeysnamesarray actionname actionparams activateaddons activatedaddons activatekey
 syn keyword sqfCommand      add3denconnection add3deneventhandler add3denlayer addaction addbackpack addbackpackcargo
-syn keyword sqfCommand      addbackpackcargoglobal addbackpackglobal addcamshake addcuratoraddons addcuratorcameraarea
-syn keyword sqfCommand      addcuratoreditableobjects addcuratoreditingarea addcuratorpoints addeditorobject
-syn keyword sqfCommand      addeventhandler addforce addforcegeneratorrtd addgoggles addgroupicon addhandgunitem
-syn keyword sqfCommand      addheadgear additem additemcargo additemcargoglobal additempool additemtobackpack
-syn keyword sqfCommand      additemtouniform additemtovest addlivestats addmagazine addmagazineammocargo
-syn keyword sqfCommand      addmagazinecargo addmagazinecargoglobal addmagazineglobal addmagazinepool addmagazines
-syn keyword sqfCommand      addmagazineturret addmenu addmenuitem addmissioneventhandler addmpeventhandler
-syn keyword sqfCommand      addmusiceventhandler addownedmine addplayerscores addprimaryweaponitem
-syn keyword sqfCommand      addpublicvariableeventhandler addrating addresources addscore addscoreside
-syn keyword sqfCommand      addsecondaryweaponitem addswitchableunit addteammember addtoremainscollector addtorque
-syn keyword sqfCommand      adduniform addvehicle addvest addwaypoint addweapon addweaponcargo addweaponcargoglobal
-syn keyword sqfCommand      addweaponglobal addweaponitem addweaponpool addweaponturret addweaponwithattachmentscargo
-syn keyword sqfCommand      addweaponwithattachmentscargoglobal admin agent agents agltoasl aimedattarget aimpos
-syn keyword sqfCommand      airdensitycurvertd airdensityrtd airplanethrottle airportside aisfinishheal alive
-syn keyword sqfCommand      all3denentities allairports allcontrols allcurators allcutlayers alldead alldeadmen
-syn keyword sqfCommand      alldisplays allgroups allmapmarkers allmines allmissionobjects allow3dmode
+syn keyword sqfCommand      addbackpackcargoglobal addbackpackglobal addbinocularitem addcamshake addcuratoraddons
+syn keyword sqfCommand      addcuratorcameraarea addcuratoreditableobjects addcuratoreditingarea addcuratorpoints
+syn keyword sqfCommand      addeditorobject addeventhandler addforce addforcegeneratorrtd addgoggles addgroupicon
+syn keyword sqfCommand      addhandgunitem addheadgear additem additemcargo additemcargoglobal additempool
+syn keyword sqfCommand      additemtobackpack additemtouniform additemtovest addlivestats addmagazine
+syn keyword sqfCommand      addmagazineammocargo addmagazinecargo addmagazinecargoglobal addmagazineglobal
+syn keyword sqfCommand      addmagazinepool addmagazines addmagazineturret addmenu addmenuitem addmissioneventhandler
+syn keyword sqfCommand      addmpeventhandler addmusiceventhandler addonfiles addownedmine addplayerscores
+syn keyword sqfCommand      addprimaryweaponitem addpublicvariableeventhandler addrating addresources addscore
+syn keyword sqfCommand      addscoreside addsecondaryweaponitem addswitchableunit addteammember addtoremainscollector
+syn keyword sqfCommand      addtorque adduniform adduseractioneventhandler addvehicle addvest addwaypoint addweapon
+syn keyword sqfCommand      addweaponcargo addweaponcargoglobal addweaponglobal addweaponitem addweaponpool
+syn keyword sqfCommand      addweaponturret addweaponwithattachmentscargo addweaponwithattachmentscargoglobal admin
+syn keyword sqfCommand      agent agents agltoasl aimedattarget aimpos airdensitycurvertd airdensityrtd airplanethrottle
+syn keyword sqfCommand      airportside aisfinishheal alive all3denentities allactivetitleeffects alladdonsinfo
+syn keyword sqfCommand      allairports allcontrols allcurators allcutlayers alldead alldeadmen alldiarysubjects
+syn keyword sqfCommand      alldisplays allgroups alllods allmapmarkers allmines allmissionobjects allow3dmode
 syn keyword sqfCommand      allowcrewinimmobile allowcuratorlogicignoreareas allowdamage allowdammage
 syn keyword sqfCommand      allowfileoperations allowfleeing allowgetin allowsprint allplayers allsimpleobjects allsites
-syn keyword sqfCommand      allturrets allunits allunitsuav allvariables ammo ammoonpylon and animate animatebay
-syn keyword sqfCommand      animatedoor animatepylon animatesource animationnames animationphase animationsourcephase
-syn keyword sqfCommand      animationstate append apply armorypoints arrayintersect asin asltoagl asltoatl assert
-syn keyword sqfCommand      assignascargo assignascargoindex assignascommander assignasdriver assignasgunner
-syn keyword sqfCommand      assignasturret assigncurator assignedcargo assignedcommander assigneddriver assignedgunner
-syn keyword sqfCommand      assigneditems assignedtarget assignedteam assignedvehicle assignedvehiclerole assignitem
-syn keyword sqfCommand      assignteam assigntoairport atan atan2 atg atltoasl attachedobject attachedobjects attachedto
-syn keyword sqfCommand      attachobject attachto attackenabled backpack backpackcargo backpackcontainer backpackitems
-syn keyword sqfCommand      backpackmagazines backpackspacefor behaviour benchmark bezierinterpolation binocular blufor
-syn keyword sqfCommand      boundingbox boundingboxreal boundingcenter breakout breakto briefingname buildingexit
+syn keyword sqfCommand      allturrets allunits allunitsuav allusers allvariables ambienttemperature ammo ammoonpylon
+syn keyword sqfCommand      and animate animatebay animatedoor animatepylon animatesource animationnames animationphase
+syn keyword sqfCommand      animationsourcephase animationstate apertureparams append apply armorypoints arrayintersect
+syn keyword sqfCommand      asin asltoagl asltoatl assert assignascargo assignascargoindex assignascommander
+syn keyword sqfCommand      assignasdriver assignasgunner assignasturret assigncurator assignedcargo assignedcommander
+syn keyword sqfCommand      assigneddriver assignedgunner assigneditems assignedtarget assignedteam assignedvehicle
+syn keyword sqfCommand      assignedvehiclerole assignitem assignteam assigntoairport atan atan2 atg atltoasl
+syn keyword sqfCommand      attachedobject attachedobjects attachedto attachobject attachto attackenabled backpack
+syn keyword sqfCommand      backpackcargo backpackcontainer backpackitems backpackmagazines backpackspacefor behaviour
+syn keyword sqfCommand      benchmark bezierinterpolation binocular binocularitems binocularmagazine blufor boundingbox
+syn keyword sqfCommand      boundingboxreal boundingcenter break breakout breakto breakwith briefingname buildingexit
 syn keyword sqfCommand      buildingpos buldozer_enableroaddiag buldozer_isenabledroaddiag buldozer_loadnewroads
 syn keyword sqfCommand      buldozer_reloadopermap buttonaction buttonsetaction cadetmode calculatepath
 syn keyword sqfCommand      calculateplayervisibilitybyfriendly camcommand camcommit camcommitprepared camcommitted
@@ -53,145 +55,159 @@ syn keyword sqfCommand      campreparedir campreparedive campreparefocus camprep
 syn keyword sqfCommand      campreparerelpos campreparetarget camsetbank camsetdir camsetdive camsetfocus camsetfov
 syn keyword sqfCommand      camsetfovrange camsetpos camsetrelpos camsettarget camtarget camusenvg canadd
 syn keyword sqfCommand      canadditemtobackpack canadditemtouniform canadditemtovest cancelsimpletaskdestination
-syn keyword sqfCommand      canfire canmove canslingload canstand cansuspend cantriggerdynamicsimulation
+syn keyword sqfCommand      candeployweapon canfire canmove canslingload canstand cansuspend cantriggerdynamicsimulation
 syn keyword sqfCommand      canunloadincombat canvehiclecargo captive captivenum cbchecked cbsetchecked ceil
 syn keyword sqfCommand      channelenabled cheatsenabled checkaifeature checkvisibility classname clear3denattribute
 syn keyword sqfCommand      clear3deninventory clearallitemsfrombackpack clearbackpackcargo clearbackpackcargoglobal
 syn keyword sqfCommand      clearforcesrtd cleargroupicons clearitemcargo clearitemcargoglobal clearitempool
 syn keyword sqfCommand      clearmagazinecargo clearmagazinecargoglobal clearmagazinepool clearoverlay clearradio
 syn keyword sqfCommand      clearweaponcargo clearweaponcargoglobal clearweaponpool clientowner closedialog closedisplay
-syn keyword sqfCommand      closeoverlay collapseobjecttree collect3denhistory collectivertd combatmode
+syn keyword sqfCommand      closeoverlay collapseobjecttree collect3denhistory collectivertd combatbehaviour combatmode
 syn keyword sqfCommand      commandartilleryfire commandchat commander commandfire commandfollow commandgetout
 syn keyword sqfCommand      commandingmenu commandmove commandradio commandstop commandsuppressivefire commandtarget
-syn keyword sqfCommand      commandwatch comment commitoverlay completedfsm composetext configclasses configfile
-syn keyword sqfCommand      confighierarchy configname confignull configproperties configsourceaddonlist configsourcemod
-syn keyword sqfCommand      configsourcemodlist confirmsensortarget connectterminaltouav controlsgroupctrl
-syn keyword sqfCommand      copyfromclipboard copytoclipboard copywaypoints cos countenemy countfriendly countside
-syn keyword sqfCommand      counttype countunknown create3dencomposition create3denentity createagent createcenter
-syn keyword sqfCommand      createdialog creatediarylink creatediaryrecord creatediarysubject createdisplay
-syn keyword sqfCommand      creategeardialog creategroup createguardedpoint createlocation createmarker
-syn keyword sqfCommand      createmarkerlocal createmenu createmine createmissiondisplay creatempcampaigndisplay
-syn keyword sqfCommand      createsimpleobject createsimpletask createsite createsoundsource createtask createteam
-syn keyword sqfCommand      createtrigger createunit createvehicle createvehiclecrew createvehiclelocal crew ctaddheader
-syn keyword sqfCommand      ctaddrow ctclear ctcursel ctdata ctfindheaderrows ctfindrowheader ctheadercontrols
-syn keyword sqfCommand      ctheadercount ctremoveheaders ctremoverows ctrlactivate ctrladdeventhandler ctrlangle
-syn keyword sqfCommand      ctrlanimatemodel ctrlanimationphasemodel ctrlautoscrolldelay ctrlautoscrollrewind
-syn keyword sqfCommand      ctrlautoscrollspeed ctrlchecked ctrlclassname ctrlcommit ctrlcommitted ctrlcreate ctrldelete
-syn keyword sqfCommand      ctrlenable ctrlenabled ctrlfade ctrlhtmlloaded ctrlidc ctrlidd ctrlmapanimadd
+syn keyword sqfCommand      commandwatch comment commitoverlay compilescript completedfsm composetext configclasses
+syn keyword sqfCommand      configfile confighierarchy configname confignull configof configproperties
+syn keyword sqfCommand      configsourceaddonlist configsourcemod configsourcemodlist confirmsensortarget
+syn keyword sqfCommand      connectterminaltouav connecttoserver continue continuewith controlsgroupctrl
+syn keyword sqfCommand      conversationdisabled copyfromclipboard copytoclipboard copywaypoints cos countenemy
+syn keyword sqfCommand      countfriendly countside counttype countunknown create3dencomposition create3denentity
+syn keyword sqfCommand      createagent createcenter createdialog creatediarylink creatediaryrecord creatediarysubject
+syn keyword sqfCommand      createdisplay creategeardialog creategroup createguardedpoint createhashmap
+syn keyword sqfCommand      createhashmapfromarray createlocation createmarker createmarkerlocal createmenu createmine
+syn keyword sqfCommand      createmissiondisplay creatempcampaigndisplay createsimpleobject createsimpletask createsite
+syn keyword sqfCommand      createsoundsource createtask createteam createtrigger createunit createvehicle
+syn keyword sqfCommand      createvehiclecrew createvehiclelocal crew ctaddheader ctaddrow ctclear ctcursel ctdata
+syn keyword sqfCommand      ctfindheaderrows ctfindrowheader ctheadercontrols ctheadercount ctremoveheaders ctremoverows
+syn keyword sqfCommand      ctrlactivate ctrladdeventhandler ctrlangle ctrlanimatemodel ctrlanimationphasemodel
+syn keyword sqfCommand      ctrlautoscrolldelay ctrlautoscrollrewind ctrlautoscrollspeed ctrlbackgroundcolor ctrlchecked
+syn keyword sqfCommand      ctrlclassname ctrlcommit ctrlcommitted ctrlcreate ctrldelete ctrlenable ctrlenabled ctrlfade
+syn keyword sqfCommand      ctrlfontheight ctrlforegroundcolor ctrlhtmlloaded ctrlidc ctrlidd ctrlmapanimadd
 syn keyword sqfCommand      ctrlmapanimclear ctrlmapanimcommit ctrlmapanimdone ctrlmapcursor ctrlmapmouseover
-syn keyword sqfCommand      ctrlmapscale ctrlmapscreentoworld ctrlmapworldtoscreen ctrlmodel ctrlmodeldirandup
-syn keyword sqfCommand      ctrlmodelscale ctrlparent ctrlparentcontrolsgroup ctrlposition ctrlremovealleventhandlers
-syn keyword sqfCommand      ctrlremoveeventhandler ctrlscale ctrlsetactivecolor ctrlsetangle ctrlsetautoscrolldelay
-syn keyword sqfCommand      ctrlsetautoscrollrewind ctrlsetautoscrollspeed ctrlsetbackgroundcolor ctrlsetchecked
-syn keyword sqfCommand      ctrlsetdisabledcolor ctrlseteventhandler ctrlsetfade ctrlsetfocus ctrlsetfont ctrlsetfonth1
-syn keyword sqfCommand      ctrlsetfonth1b ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3 ctrlsetfonth3b ctrlsetfonth4
-syn keyword sqfCommand      ctrlsetfonth4b ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6 ctrlsetfonth6b ctrlsetfontheight
+syn keyword sqfCommand      ctrlmapscale ctrlmapscreentoworld ctrlmapsetposition ctrlmapworldtoscreen ctrlmodel
+syn keyword sqfCommand      ctrlmodeldirandup ctrlmodelscale ctrlmouseposition ctrlparent ctrlparentcontrolsgroup
+syn keyword sqfCommand      ctrlposition ctrlremovealleventhandlers ctrlremoveeventhandler ctrlscale ctrlscrollvalues
+syn keyword sqfCommand      ctrlsetactivecolor ctrlsetangle ctrlsetautoscrolldelay ctrlsetautoscrollrewind
+syn keyword sqfCommand      ctrlsetautoscrollspeed ctrlsetbackgroundcolor ctrlsetchecked ctrlsetdisabledcolor
+syn keyword sqfCommand      ctrlseteventhandler ctrlsetfade ctrlsetfocus ctrlsetfont ctrlsetfonth1 ctrlsetfonth1b
+syn keyword sqfCommand      ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3 ctrlsetfonth3b ctrlsetfonth4 ctrlsetfonth4b
+syn keyword sqfCommand      ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6 ctrlsetfonth6b ctrlsetfontheight
 syn keyword sqfCommand      ctrlsetfontheighth1 ctrlsetfontheighth2 ctrlsetfontheighth3 ctrlsetfontheighth4
 syn keyword sqfCommand      ctrlsetfontheighth5 ctrlsetfontheighth6 ctrlsetfontheightsecondary ctrlsetfontp
 syn keyword sqfCommand      ctrlsetfontpb ctrlsetfontsecondary ctrlsetforegroundcolor ctrlsetmodel ctrlsetmodeldirandup
-syn keyword sqfCommand      ctrlsetmodelscale ctrlsetpixelprecision ctrlsetposition ctrlsetpositionh ctrlsetpositionw
-syn keyword sqfCommand      ctrlsetpositionx ctrlsetpositiony ctrlsetscale ctrlsetstructuredtext ctrlsettext
-syn keyword sqfCommand      ctrlsettextcolor ctrlsettextcolorsecondary ctrlsettextsecondary ctrlsettooltip
-syn keyword sqfCommand      ctrlsettooltipcolorbox ctrlsettooltipcolorshade ctrlsettooltipcolortext ctrlshow ctrlshown
-syn keyword sqfCommand      ctrltext ctrltextheight ctrltextsecondary ctrltextwidth ctrltype ctrlvisible ctrowcontrols
-syn keyword sqfCommand      ctrowcount ctsetcursel ctsetdata ctsetheadertemplate ctsetrowtemplate ctsetvalue ctvalue
-syn keyword sqfCommand      curatoraddons curatorcamera curatorcameraarea curatorcameraareaceiling curatorcoef
-syn keyword sqfCommand      curatoreditableobjects curatoreditingarea curatoreditingareatype curatormouseover
-syn keyword sqfCommand      curatorpoints curatorregisteredobjects curatorselected curatorwaypointcost
-syn keyword sqfCommand      current3denoperation currentchannel currentcommand currentmagazine currentmagazinedetail
-syn keyword sqfCommand      currentmagazinedetailturret currentmagazineturret currentmuzzle currentnamespace currenttask
-syn keyword sqfCommand      currenttasks currentthrowable currentvisionmode currentwaypoint currentweapon
-syn keyword sqfCommand      currentweaponmode currentweaponturret currentzeroing cursorobject cursortarget customchat
-syn keyword sqfCommand      customradio customwaypointposition cutfadeout cutobj cutrsc cuttext damage date datetonumber
-syn keyword sqfCommand      daytime deactivatekey debriefingtext debugfsm debuglog decaygraphvalues deg
-syn keyword sqfCommand      delete3denentities deleteat deletecenter deletecollection deleteeditorobject deletegroup
-syn keyword sqfCommand      deletegroupwhenempty deleteidentity deletelocation deletemarker deletemarkerlocal
-syn keyword sqfCommand      deleterange deleteresources deletesite deletestatus deleteteam deletevehicle
-syn keyword sqfCommand      deletevehiclecrew deletewaypoint detach detectedmines diag_activemissionfsms
-syn keyword sqfCommand      diag_activescripts diag_activesqfscripts diag_activesqsscripts diag_codeperformance
-syn keyword sqfCommand      diag_dynamicsimulationend diag_fps diag_fpsmin diag_frameno diag_lightnewload diag_log
-syn keyword sqfCommand      diag_setlightnew diag_ticktime dialog diarysubjectexists didjip didjipowner difficulty
-syn keyword sqfCommand      difficultyenabled difficultyenabledrtd difficultyoption direction directsay disableai
+syn keyword sqfCommand      ctrlsetmodelscale ctrlsetmouseposition ctrlsetpixelprecision ctrlsetposition
+syn keyword sqfCommand      ctrlsetpositionh ctrlsetpositionw ctrlsetpositionx ctrlsetpositiony ctrlsetscale
+syn keyword sqfCommand      ctrlsetscrollvalues ctrlsetstructuredtext ctrlsettext ctrlsettextcolor
+syn keyword sqfCommand      ctrlsettextcolorsecondary ctrlsettextsecondary ctrlsettextselection ctrlsettooltip
+syn keyword sqfCommand      ctrlsettooltipcolorbox ctrlsettooltipcolorshade ctrlsettooltipcolortext
+syn keyword sqfCommand      ctrlsettooltipmaxwidth ctrlseturl ctrlshow ctrlshown ctrlstyle ctrltext ctrltextcolor
+syn keyword sqfCommand      ctrltextheight ctrltextsecondary ctrltextselection ctrltextwidth ctrltooltip ctrltype
+syn keyword sqfCommand      ctrlurl ctrlvisible ctrowcontrols ctrowcount ctsetcursel ctsetdata ctsetheadertemplate
+syn keyword sqfCommand      ctsetrowtemplate ctsetvalue ctvalue curatoraddons curatorcamera curatorcameraarea
+syn keyword sqfCommand      curatorcameraareaceiling curatorcoef curatoreditableobjects curatoreditingarea
+syn keyword sqfCommand      curatoreditingareatype curatormouseover curatorpoints curatorregisteredobjects
+syn keyword sqfCommand      curatorselected curatorwaypointcost current3denoperation currentchannel currentcommand
+syn keyword sqfCommand      currentmagazine currentmagazinedetail currentmagazinedetailturret currentmagazineturret
+syn keyword sqfCommand      currentmuzzle currentnamespace currentpilot currenttask currenttasks currentthrowable
+syn keyword sqfCommand      currentvisionmode currentwaypoint currentweapon currentweaponmode currentweaponturret
+syn keyword sqfCommand      currentzeroing cursorobject cursortarget customchat customradio customwaypointposition
+syn keyword sqfCommand      cutfadeout cutobj cutrsc cuttext damage date datetonumber daytime deactivatekey
+syn keyword sqfCommand      debriefingtext debugfsm debuglog decaygraphvalues deg delete3denentities deleteat
+syn keyword sqfCommand      deletecenter deletecollection deleteeditorobject deletegroup deletegroupwhenempty
+syn keyword sqfCommand      deleteidentity deletelocation deletemarker deletemarkerlocal deleterange deleteresources
+syn keyword sqfCommand      deletesite deletestatus deleteteam deletevehicle deletevehiclecrew deletewaypoint detach
+syn keyword sqfCommand      detectedmines diag_activemissionfsms diag_activescripts diag_activesqfscripts
+syn keyword sqfCommand      diag_activesqsscripts diag_allmissioneventhandlers diag_codeperformance diag_deltatime
+syn keyword sqfCommand      diag_dynamicsimulationend diag_fps diag_fpsmin diag_frameno diag_lightnewload diag_localized
+syn keyword sqfCommand      diag_log diag_scope diag_setlightnew diag_stacktrace diag_ticktime dialog diaryrecordnull
+syn keyword sqfCommand      diarysubjectexists didjip didjipowner difficulty difficultyenabled difficultyenabledrtd
+syn keyword sqfCommand      difficultyoption direction directionstabilizationenabled directsay disableai
 syn keyword sqfCommand      disablecollisionwith disableconversation disabledebriefingstats disablemapindicators
 syn keyword sqfCommand      disablenvgequipment disableremotesensors disableserialization disabletiequipment
-syn keyword sqfCommand      disableuavconnectability disableuserinput displayaddeventhandler displayctrl displayparent
-syn keyword sqfCommand      displayremovealleventhandlers displayremoveeventhandler displayseteventhandler dissolveteam
-syn keyword sqfCommand      distance distance2d distancesqr distributionregion do3denaction doartilleryfire dofire
-syn keyword sqfCommand      dofollow dogetout domove doorphase dostop dosuppressivefire dotarget dowatch drawarrow
-syn keyword sqfCommand      drawellipse drawicon drawicon3d drawline drawline3d drawlink drawlocation drawpolygon
-syn keyword sqfCommand      drawrectangle drawtriangle driver drop dynamicsimulationdistance
+syn keyword sqfCommand      disableuavconnectability disableuserinput displayaddeventhandler displaychild displayctrl
+syn keyword sqfCommand      displayparent displayremovealleventhandlers displayremoveeventhandler displayseteventhandler
+syn keyword sqfCommand      dissolveteam distance distance2d distancesqr distributionregion do3denaction doartilleryfire
+syn keyword sqfCommand      dofire dofollow dogetout domove doorphase dostop dosuppressivefire dotarget dowatch
+syn keyword sqfCommand      drawarrow drawellipse drawicon drawicon3d drawline drawline3d drawlink drawlocation
+syn keyword sqfCommand      drawpolygon drawrectangle drawtriangle driver drop dynamicsimulationdistance
 syn keyword sqfCommand      dynamicsimulationdistancecoef dynamicsimulationenabled dynamicsimulationsystemenabled echo
-syn keyword sqfCommand      edit3denmissionattributes editobject editorseteventhandler effectivecommander emptypositions
-syn keyword sqfCommand      enableai enableaifeature enableaimprecision enableattack enableaudiofeature
-syn keyword sqfCommand      enableautostartuprtd enableautotrimrtd enablecamshake enablecaustics enablechannel
-syn keyword sqfCommand      enablecollisionwith enablecopilot enabledebriefingstats enablediaglegend
-syn keyword sqfCommand      enabledynamicsimulation enabledynamicsimulationsystem enableenddialog enableengineartillery
-syn keyword sqfCommand      enableenvironment enablefatigue enablegunlights enableinfopanelcomponent enableirlasers
-syn keyword sqfCommand      enablemimics enablepersonturret enableradio enablereload enableropeattach
-syn keyword sqfCommand      enablesatnormalondetail enablesaving enablesentences enablesimulation enablesimulationglobal
-syn keyword sqfCommand      enablestamina enablestressdamage enableteamswitch enabletraffic enableuavconnectability
-syn keyword sqfCommand      enableuavwaypoints enablevehiclecargo enablevehiclesensor enableweapondisassembly endl
-syn keyword sqfCommand      endloadingscreen endmission engineon enginesisonrtd enginespowerrtd enginesrpmrtd
-syn keyword sqfCommand      enginestorquertd entities environmentenabled estimatedendservertime estimatedtimeleft
-syn keyword sqfCommand      evalobjectargument everybackpack everycontainer exec execeditorscript exit exp
-syn keyword sqfCommand      expecteddestination exportjipmessages eyedirection eyepos face faction fademusic faderadio
-syn keyword sqfCommand      fadesound fadespeech failmission fillweaponsfrompool find findcover finddisplay
-syn keyword sqfCommand      findeditorobject findemptyposition findemptypositionready findif findnearestenemy
-syn keyword sqfCommand      finishmissioninit finite fire fireattarget firstbackpack flag flaganimationphase flagowner
-syn keyword sqfCommand      flagside flagtexture fleeing floor flyinheight flyinheightasl fog fogforecast fogparams
-syn keyword sqfCommand      forceadduniform forceatpositionrtd forcedmap forceend forceflagtexture forcefollowroad
-syn keyword sqfCommand      forcegeneratorrtd forcemap forcerespawn forcespeed forcewalk forceweaponfire
-syn keyword sqfCommand      forceweatherchange foreachmember foreachmemberagent foreachmemberteam forgettarget format
-syn keyword sqfCommand      formation formationdirection formationleader formationmembers formationposition
-syn keyword sqfCommand      formationtask formattext formleader freelook fromeditor fuel fullcrew gearidcammocount
-syn keyword sqfCommand      gearslotammocount gearslotdata get3denactionstate get3denattribute get3dencamera
-syn keyword sqfCommand      get3denconnections get3denentity get3denentityid get3dengrid get3deniconsvisible
-syn keyword sqfCommand      get3denlayerentities get3denlinesvisible get3denmissionattribute get3denmouseover
-syn keyword sqfCommand      get3denselected getaimingcoef getallenvsoundcontrollers getallhitpointsdamage
-syn keyword sqfCommand      getallownedmines getallsoundcontrollers getammocargo getanimaimprecision getanimspeedcoef
-syn keyword sqfCommand      getarray getartilleryammo getartillerycomputersettings getartilleryeta
-syn keyword sqfCommand      getassignedcuratorlogic getassignedcuratorunit getaudiooptionvolumes getbackpackcargo
+syn keyword sqfCommand      edit3denmissionattributes editobject editorseteventhandler effectivecommander
+syn keyword sqfCommand      elevateperiscope emptypositions enableai enableaifeature enableaimprecision enableattack
+syn keyword sqfCommand      enableaudiofeature enableautostartuprtd enableautotrimrtd enablecamshake enablecaustics
+syn keyword sqfCommand      enablechannel enablecollisionwith enablecopilot enabledebriefingstats enablediaglegend
+syn keyword sqfCommand      enabledirectionstabilization enabledynamicsimulation enabledynamicsimulationsystem
+syn keyword sqfCommand      enableenddialog enableengineartillery enableenvironment enablefatigue enablegunlights
+syn keyword sqfCommand      enableinfopanelcomponent enableirlasers enablemimics enablepersonturret enableradio
+syn keyword sqfCommand      enablereload enableropeattach enablesatnormalondetail enablesaving enablesentences
+syn keyword sqfCommand      enablesimulation enablesimulationglobal enablestamina enablestressdamage enableteamswitch
+syn keyword sqfCommand      enabletraffic enableuavconnectability enableuavwaypoints enablevehiclecargo
+syn keyword sqfCommand      enablevehiclesensor enableweapondisassembly endl endloadingscreen endmission engineon
+syn keyword sqfCommand      enginesisonrtd enginespowerrtd enginesrpmrtd enginestorquertd entities environmentenabled
+syn keyword sqfCommand      environmentvolume estimatedendservertime estimatedtimeleft evalobjectargument everybackpack
+syn keyword sqfCommand      everycontainer exec execeditorscript exit exp expecteddestination exportjipmessages
+syn keyword sqfCommand      eyedirection eyepos face faction fadeenvironment fademusic faderadio fadesound fadespeech
+syn keyword sqfCommand      failmission fileexists fillweaponsfrompool find findcover finddisplay findeditorobject
+syn keyword sqfCommand      findemptyposition findemptypositionready findif findnearestenemy finishmissioninit finite
+syn keyword sqfCommand      fire fireattarget firstbackpack flag flaganimationphase flagowner flagside flagtexture
+syn keyword sqfCommand      flatten fleeing floor flyinheight flyinheightasl focusedctrl fog fogforecast fogparams
+syn keyword sqfCommand      forceadduniform forceatpositionrtd forcecadetdifficulty forcedmap forceend forceflagtexture
+syn keyword sqfCommand      forcefollowroad forcegeneratorrtd forcemap forcerespawn forcespeed forceunicode forcewalk
+syn keyword sqfCommand      forceweaponfire forceweatherchange foreachmember foreachmemberagent foreachmemberteam
+syn keyword sqfCommand      forgettarget format formation formationdirection formationleader formationmembers
+syn keyword sqfCommand      formationposition formationtask formattext formleader freelook fromeditor fuel fullcrew
+syn keyword sqfCommand      gearidcammocount gearslotammocount gearslotdata gesturestate get get3denactionstate
+syn keyword sqfCommand      get3denattribute get3dencamera get3denconnections get3denentity get3denentityid get3dengrid
+syn keyword sqfCommand      get3deniconsvisible get3denlayerentities get3denlinesvisible get3denmissionattribute
+syn keyword sqfCommand      get3denmouseover get3denselected getaimingcoef getallenvsoundcontrollers
+syn keyword sqfCommand      getallhitpointsdamage getallownedmines getallpylonsinfo getallsoundcontrollers
+syn keyword sqfCommand      getallunittraits getammocargo getanimaimprecision getanimspeedcoef getarray getartilleryammo
+syn keyword sqfCommand      getartillerycomputersettings getartilleryeta getassetdlcinfo getassignedcuratorlogic
+syn keyword sqfCommand      getassignedcuratorunit getattacktarget getaudiooptionvolumes getbackpackcargo
 syn keyword sqfCommand      getbleedingremaining getburningvalue getcalculateplayervisibilitybyfriendly
 syn keyword sqfCommand      getcameraviewdirection getcargoindex getcenterofmass getclientstate getclientstatenumber
-syn keyword sqfCommand      getcompatiblepylonmagazines getconnecteduav getcontainermaxload getcursorobjectparams
-syn keyword sqfCommand      getcustomaimcoef getcustomsoundcontroller getcustomsoundcontrollercount getdammage
-syn keyword sqfCommand      getdescription getdir getdirvisual getdlcassetsusage getdlcassetsusagebyname getdlcs
-syn keyword sqfCommand      getdlcusagetime geteditorcamera geteditormode geteditorobjectscope getelevationoffset
-syn keyword sqfCommand      getenginetargetrpmrtd getenvsoundcontroller getfatigue getfieldmanualstartpage
-syn keyword sqfCommand      getforcedflagtexture getfriend getfsmvariable getfuelcargo getgraphvalues getgroupicon
-syn keyword sqfCommand      getgroupiconparams getgroupicons gethidefrom gethit gethitindex gethitpointdamage
-syn keyword sqfCommand      getitemcargo getmagazinecargo getmarkercolor getmarkerpos getmarkersize getmarkertype
+syn keyword sqfCommand      getcompatiblepylonmagazines getconnecteduav getcontainermaxload getcruisecontrol
+syn keyword sqfCommand      getcursorobjectparams getcustomaimcoef getcustomsoundcontroller
+syn keyword sqfCommand      getcustomsoundcontrollercount getdammage getdebriefingtext getdescription getdir
+syn keyword sqfCommand      getdirvisual getdiverstate getdlcassetsusage getdlcassetsusagebyname getdlcs getdlcusagetime
+syn keyword sqfCommand      geteditorcamera geteditormode geteditorobjectscope getelevationoffset getenginetargetrpmrtd
+syn keyword sqfCommand      getenvsoundcontroller getfatigue getfieldmanualstartpage getforcedflagtexture getfriend
+syn keyword sqfCommand      getfsmvariable getfuelcargo getgraphvalues getgroupicon getgroupiconparams getgroupicons
+syn keyword sqfCommand      gethidefrom gethit gethitindex gethitpointdamage getitemcargo getlighting getlightingat
+syn keyword sqfCommand      getloadedmodsinfo getmagazinecargo getmarkercolor getmarkerpos getmarkersize getmarkertype
 syn keyword sqfCommand      getmass getmissionconfig getmissionconfigvalue getmissiondlcs getmissionlayerentities
-syn keyword sqfCommand      getmissionlayers getmodelinfo getmouseposition getmusicplayedtime getnumber
-syn keyword sqfCommand      getobjectargument getobjectchildren getobjectdlc getobjectmaterials getobjectproxy
-syn keyword sqfCommand      getobjecttextures getobjecttype getobjectviewdistance getoxygenremaining getpersonuseddlcs
-syn keyword sqfCommand      getpilotcameradirection getpilotcameraposition getpilotcamerarotation getpilotcameratarget
-syn keyword sqfCommand      getplatenumber getplayerchannel getplayerscores getplayeruid getpos getposasl
-syn keyword sqfCommand      getposaslvisual getposaslw getposatl getposatlvisual getposvisual getposworld
-syn keyword sqfCommand      getpylonmagazines getreldir getrelpos getremotesensorsdisabled getrepaircargo getresolution
-syn keyword sqfCommand      getrotorbrakertd getshadowdistance getshotparents getslingload getsoundcontroller
-syn keyword sqfCommand      getsoundcontrollerresult getspeed getstamina getstatvalue getsubtitleoptions getsuppression
-syn keyword sqfCommand      getterraingrid getterrainheightasl gettext gettotaldlcusagetime gettrimoffsetrtd
-syn keyword sqfCommand      getunitloadout getunittrait getusermfdtext getusermfdvalue getvariable getvehiclecargo
-syn keyword sqfCommand      getweaponcargo getweaponsway getwingsorientationrtd getwingspositionrtd getwppos glanceat
-syn keyword sqfCommand      globalchat globalradio goggles goto group groupchat groupfromnetid groupiconselectable
-syn keyword sqfCommand      groupiconsvisible groupid groupowner groupradio groupselectedunits groupselectunit gunner
-syn keyword sqfCommand      gusts halt handgunitems handgunmagazine handgunweapon handshit hasinterface haspilotcamera
-syn keyword sqfCommand      hasweapon hcallgroups hcgroupparams hcleader hcremoveallgroups hcremovegroup hcselected
-syn keyword sqfCommand      hcselectgroup hcsetgroup hcshowbar hcshownbar headgear hidebody hideobject hideobjectglobal
-syn keyword sqfCommand      hideselection hint hintc hintcadet hintsilent hmd hostmission htmlload hudmovementlevels
-syn keyword sqfCommand      humidity image importallgroups importance in inarea inareaarray incapacitatedstate inflame
-syn keyword sqfCommand      inflamed infopanel infopanelcomponentenabled infopanelcomponents infopanels
-syn keyword sqfCommand      ingameuiseteventhandler inheritsfrom initambientlife inpolygon inputaction
-syn keyword sqfCommand      inrangeofartillery inserteditorobject intersect is3den is3denmultiplayer isabletobreathe
-syn keyword sqfCommand      isagent isaimprecisionenabled isarray isautohoveron isautonomous isautostartupenabledrtd
-syn keyword sqfCommand      isautotest isautotrimonrtd isbleeding isburning isclass iscollisionlighton iscopilotenabled
-syn keyword sqfCommand      isdamageallowed isdedicated isdlcavailable isengineon isequalto isequaltype isequaltypeall
-syn keyword sqfCommand      isequaltypeany isequaltypearray isequaltypeparams isfilepatchingenabled isflashlighton
-syn keyword sqfCommand      isflatempty isforcedwalk isformationleader isgroupdeletedwhenempty ishidden
-syn keyword sqfCommand      isinremainscollector isinstructorfigureenabled isirlaseron iskeyactive iskindof islaseron
-syn keyword sqfCommand      islighton islocalized ismanualfire ismarkedforcollection ismultiplayer ismultiplayersolo
-syn keyword sqfCommand      isnil isnull isnumber isobjecthidden isobjectrtd isonroad ispipenabled isplayer isrealtime
+syn keyword sqfCommand      getmissionlayers getmissionpath getmodelinfo getmouseposition getmusicplayedtime getnumber
+syn keyword sqfCommand      getobjectargument getobjectchildren getobjectdlc getobjectfov getobjectmaterials
+syn keyword sqfCommand      getobjectproxy getobjectscale getobjecttextures getobjecttype getobjectviewdistance
+syn keyword sqfCommand      getordefault getoxygenremaining getpersonuseddlcs getpilotcameradirection
+syn keyword sqfCommand      getpilotcameraposition getpilotcamerarotation getpilotcameratarget getplatenumber
+syn keyword sqfCommand      getplayerchannel getplayerid getplayerscores getplayeruid getplayervonvolume getpos
+syn keyword sqfCommand      getposasl getposaslvisual getposaslw getposatl getposatlvisual getposvisual getposworld
+syn keyword sqfCommand      getposworldvisual getpylonmagazines getreldir getrelpos getremotesensorsdisabled
+syn keyword sqfCommand      getrepaircargo getresolution getroadinfo getrotorbrakertd getsensortargets getsensorthreats
+syn keyword sqfCommand      getshadowdistance getshotparents getslingload getsoundcontroller getsoundcontrollerresult
+syn keyword sqfCommand      getspeed getstamina getstatvalue getsteamfriendsservers getsubtitleoptions getsuppression
+syn keyword sqfCommand      getterraingrid getterrainheightasl gettext gettextraw gettextureinfo gettextwidth
+syn keyword sqfCommand      gettotaldlcusagetime gettrimoffsetrtd getunitloadout getunittrait getuserinfo getusermfdtext
+syn keyword sqfCommand      getusermfdvalue getvariable getvehiclecargo getvehicletipars getweaponcargo getweaponsway
+syn keyword sqfCommand      getwingsorientationrtd getwingspositionrtd getwppos glanceat globalchat globalradio goggles
+syn keyword sqfCommand      goto group groupchat groupfromnetid groupiconselectable groupiconsvisible groupid groupowner
+syn keyword sqfCommand      groupradio groupselectedunits groupselectunit gunner gusts halt handgunitems handgunmagazine
+syn keyword sqfCommand      handgunweapon handshit hashvalue hasinterface haspilotcamera hasweapon hcallgroups
+syn keyword sqfCommand      hcgroupparams hcleader hcremoveallgroups hcremovegroup hcselected hcselectgroup hcsetgroup
+syn keyword sqfCommand      hcshowbar hcshownbar headgear hidebody hideobject hideobjectglobal hideselection hint hintc
+syn keyword sqfCommand      hintcadet hintsilent hmd hostmission htmlload hudmovementlevels humidity image
+syn keyword sqfCommand      importallgroups importance in inarea inareaarray incapacitatedstate inflame inflamed
+syn keyword sqfCommand      infopanel infopanelcomponentenabled infopanelcomponents infopanels ingameuiseteventhandler
+syn keyword sqfCommand      inheritsfrom initambientlife inpolygon inputaction inrangeofartillery insert
+syn keyword sqfCommand      inserteditorobject intersect is3den is3denmultiplayer is3denpreview isabletobreathe
+syn keyword sqfCommand      isactionmenuvisible isagent isaimprecisionenabled isarray isautohoveron isautonomous
+syn keyword sqfCommand      isautostartupenabledrtd isautotest isautotrimonrtd isbleeding isburning isclass
+syn keyword sqfCommand      iscollisionlighton iscopilotenabled isdamageallowed isdedicated isdlcavailable isengineon
+syn keyword sqfCommand      isequalto isequaltype isequaltypeall isequaltypeany isequaltypearray isequaltypeparams
+syn keyword sqfCommand      isfilepatchingenabled isfinal isflashlighton isflatempty isforcedwalk isformationleader
+syn keyword sqfCommand      isgamefocused isgamepaused isgroupdeletedwhenempty ishidden isinremainscollector
+syn keyword sqfCommand      isinstructorfigureenabled isirlaseron iskeyactive iskindof islaseron islighton islocalized
+syn keyword sqfCommand      ismanualfire ismarkedforcollection ismultiplayer ismultiplayersolo isnil isnotequalto isnull
+syn keyword sqfCommand      isnumber isobjecthidden isobjectrtd isonroad ispipenabled isplayer isrealtime
 syn keyword sqfCommand      isremoteexecuted isremoteexecutedjip issensortargetconfirmed isserver isshowing3dicons
 syn keyword sqfCommand      issimpleobject issprintallowed isstaminaenabled issteammission isstreamfriendlyuienabled
 syn keyword sqfCommand      isstressdamageenabled istext istouchingground isturnedout istuthintsenabled isuavconnectable
@@ -199,203 +215,217 @@ syn keyword sqfCommand      isuavconnected isuicontext isuniformallowed isvehicl
 syn keyword sqfCommand      isvehiclesensorenabled iswalking isweapondeployed isweaponrested itemcargo items
 syn keyword sqfCommand      itemswithmagazines join joinas joinassilent joinsilent joinstring kbadddatabase
 syn keyword sqfCommand      kbadddatabasetargets kbaddtopic kbhastopic kbreact kbremovetopic kbtell kbwassaid keyimage
-syn keyword sqfCommand      keyname knowsabout land landat landresult language lasertarget lbadd lbclear lbcolor
+syn keyword sqfCommand      keyname keys knowsabout land landat landresult language lasertarget lbadd lbclear lbcolor
 syn keyword sqfCommand      lbcolorright lbcursel lbdata lbdelete lbisselected lbpicture lbpictureright lbselection
 syn keyword sqfCommand      lbsetcolor lbsetcolorright lbsetcursel lbsetdata lbsetpicture lbsetpicturecolor
 syn keyword sqfCommand      lbsetpicturecolordisabled lbsetpicturecolorselected lbsetpictureright lbsetpicturerightcolor
 syn keyword sqfCommand      lbsetpicturerightcolordisabled lbsetpicturerightcolorselected lbsetselectcolor
 syn keyword sqfCommand      lbsetselectcolorright lbsetselected lbsettext lbsettextright lbsettooltip lbsetvalue lbsize
-syn keyword sqfCommand      lbsort lbsortbyvalue lbtext lbtextright lbvalue leader leaderboarddeinit leaderboardgetrows
-syn keyword sqfCommand      leaderboardinit leaderboardrequestrowsfriends leaderboardrequestrowsglobal
-syn keyword sqfCommand      leaderboardrequestrowsglobalarounduser leaderboardsrequestuploadscore
-syn keyword sqfCommand      leaderboardsrequestuploadscorekeepbest leaderboardstate leavevehicle librarycredits
-syn keyword sqfCommand      librarydisclaimers lifestate lightattachobject lightdetachobject lightison lightnings
-syn keyword sqfCommand      limitspeed linearconversion linebreak lineintersects lineintersectsobjs
+syn keyword sqfCommand      lbsort lbsortby lbsortbyvalue lbtext lbtextright lbtooltip lbvalue leader leaderboarddeinit
+syn keyword sqfCommand      leaderboardgetrows leaderboardinit leaderboardrequestrowsfriends
+syn keyword sqfCommand      leaderboardrequestrowsglobal leaderboardrequestrowsglobalarounduser
+syn keyword sqfCommand      leaderboardsrequestuploadscore leaderboardsrequestuploadscorekeepbest leaderboardstate
+syn keyword sqfCommand      leavevehicle librarycredits librarydisclaimers lifestate lightattachobject lightdetachobject
+syn keyword sqfCommand      lightison lightnings limitspeed linearconversion linebreak lineintersects lineintersectsobjs
 syn keyword sqfCommand      lineintersectssurfaces lineintersectswith linkitem list listobjects listremotetargets
 syn keyword sqfCommand      listvehiclesensors ln lnbaddarray lnbaddcolumn lnbaddrow lnbclear lnbcolor lnbcolorright
 syn keyword sqfCommand      lnbcurselrow lnbdata lnbdeletecolumn lnbdeleterow lnbgetcolumnsposition lnbpicture
 syn keyword sqfCommand      lnbpictureright lnbsetcolor lnbsetcolorright lnbsetcolumnspos lnbsetcurselrow lnbsetdata
 syn keyword sqfCommand      lnbsetpicture lnbsetpicturecolor lnbsetpicturecolorright lnbsetpicturecolorselected
 syn keyword sqfCommand      lnbsetpicturecolorselectedright lnbsetpictureright lnbsettext lnbsettextright lnbsettooltip
-syn keyword sqfCommand      lnbsetvalue lnbsize lnbsort lnbsortbyvalue lnbtext lnbtextright lnbvalue load loadabs
-syn keyword sqfCommand      loadbackpack loadfile loadgame loadidentity loadmagazine loadoverlay loadstatus loaduniform
-syn keyword sqfCommand      loadvest local localize locationposition lock lockcamerato lockcargo lockdriver locked
-syn keyword sqfCommand      lockedcargo lockeddriver lockedturret lockidentity lockturret lockwp log logentities
-syn keyword sqfCommand      lognetwork lognetworkterminate lookat lookatpos magazinecargo magazines magazinesallturrets
-syn keyword sqfCommand      magazinesammo magazinesammocargo magazinesammofull magazinesdetail magazinesdetailbackpack
+syn keyword sqfCommand      lnbsetvalue lnbsize lnbsort lnbsortby lnbsortbyvalue lnbtext lnbtextright lnbvalue load
+syn keyword sqfCommand      loadabs loadbackpack loadfile loadgame loadidentity loadmagazine loadoverlay loadstatus
+syn keyword sqfCommand      loaduniform loadvest local localize localnamespace locationposition lock lockcamerato
+syn keyword sqfCommand      lockcargo lockdriver locked lockedcargo lockeddriver lockedinventory lockedturret
+syn keyword sqfCommand      lockidentity lockinventory lockturret lockwp log logentities lognetwork lognetworkterminate
+syn keyword sqfCommand      lookat lookatpos magazinecargo magazines magazinesallturrets magazinesammo
+syn keyword sqfCommand      magazinesammocargo magazinesammofull magazinesdetail magazinesdetailbackpack
 syn keyword sqfCommand      magazinesdetailuniform magazinesdetailvest magazinesturret magazineturretammo mapanimadd
 syn keyword sqfCommand      mapanimclear mapanimcommit mapanimdone mapcenteroncamera mapgridposition
-syn keyword sqfCommand      markasfinishedonsteam markeralpha markerbrush markercolor markerdir markerpos markershape
-syn keyword sqfCommand      markersize markertext markertype matrixmultiply matrixtranspose max members menuaction
-syn keyword sqfCommand      menuadd menuchecked menuclear menucollapse menudata menudelete menuenable menuenabled
-syn keyword sqfCommand      menuexpand menuhover menupicture menusetaction menusetcheck menusetdata menusetpicture
-syn keyword sqfCommand      menusetvalue menushortcut menushortcuttext menusize menusort menutext menuurl menuvalue min
-syn keyword sqfCommand      mineactive minedetectedby missiletarget missiletargetpos missionconfigfile missiondifficulty
-syn keyword sqfCommand      missionname missionnamespace missionstart missionversion mod modeltoworld modeltoworldvisual
-syn keyword sqfCommand      modeltoworldvisualworld modeltoworldworld modparams moonintensity moonphase morale move
-syn keyword sqfCommand      move3dencamera moveinany moveincargo moveincommander moveindriver moveingunner moveinturret
-syn keyword sqfCommand      moveobjecttoend moveout movetime moveto movetocompleted movetofailed musicvolume name
-syn keyword sqfCommand      namesound nearentities nearestbuilding nearestlocation nearestlocations
-syn keyword sqfCommand      nearestlocationwithdubbing nearestobject nearestobjects nearestterrainobjects nearobjects
-syn keyword sqfCommand      nearobjectsready nearroads nearsupplies neartargets needreload netid newoverlay
-syn keyword sqfCommand      nextmenuitemindex nextweatherchange nmenuitems not numberofenginesrtd numbertodate
-syn keyword sqfCommand      objectcurators objectfromnetid objectparent objstatus onbriefinggroup onbriefingnotes
-syn keyword sqfCommand      onbriefingplan onbriefingteamswitch oncommandmodechanged ondoubleclick oneachframe
-syn keyword sqfCommand      ongroupiconclick ongroupiconoverenter ongroupiconoverleave onhcgroupselectionchanged
-syn keyword sqfCommand      onmapsingleclick onplayerconnected onplayerdisconnected onpreloadfinished onpreloadstarted
-syn keyword sqfCommand      onshownewobject onteamswitch opencuratorinterface opendlcpage openmap opensteamapp
-syn keyword sqfCommand      openyoutubevideo opfor or ordergetin overcast overcastforecast owner param params
-syn keyword sqfCommand      parsenumber parsesimplearray parsetext parsingnamespace particlesquality pi pickweaponpool
-syn keyword sqfCommand      pitch pixelgrid pixelgridbase pixelgridnouiscale pixelh pixelw playableslotsnumber
-syn keyword sqfCommand      playableunits playaction playactionnow player playerrespawntime playerside playersnumber
-syn keyword sqfCommand      playgesture playmission playmove playmovenow playmusic playscriptedmission playsound
-syn keyword sqfCommand      playsound3d position positioncameratoworld posscreentoworld posworldtoscreen ppeffectadjust
-syn keyword sqfCommand      ppeffectcommit ppeffectcommitted ppeffectcreate ppeffectdestroy ppeffectenable
-syn keyword sqfCommand      ppeffectenabled ppeffectforceinnvg precision preloadcamera preloadobject preloadsound
-syn keyword sqfCommand      preloadtitleobj preloadtitlersc primaryweapon primaryweaponitems primaryweaponmagazine
-syn keyword sqfCommand      priority processdiarylink productversion profilename profilenamespace profilenamesteam
+syn keyword sqfCommand      markasfinishedonsteam markeralpha markerbrush markerchannel markercolor markerdir
+syn keyword sqfCommand      markerpolyline markerpos markershadow markershape markersize markertext markertype
+syn keyword sqfCommand      matrixmultiply matrixtranspose max members menuaction menuadd menuchecked menuclear
+syn keyword sqfCommand      menucollapse menudata menudelete menuenable menuenabled menuexpand menuhover menupicture
+syn keyword sqfCommand      menusetaction menusetcheck menusetdata menusetpicture menusetshortcut menusettext menuseturl
+syn keyword sqfCommand      menusetvalue menushortcut menushortcuttext menusize menusort menutext menuurl menuvalue
+syn keyword sqfCommand      merge min mineactive minedetectedby missiletarget missiletargetpos missionconfigfile
+syn keyword sqfCommand      missiondifficulty missionend missionname missionnamesource missionnamespace missionstart
+syn keyword sqfCommand      missionversion mod modeltoworld modeltoworldvisual modeltoworldvisualworld modeltoworldworld
+syn keyword sqfCommand      modparams moonintensity moonphase morale move move3dencamera moveinany moveincargo
+syn keyword sqfCommand      moveincommander moveindriver moveingunner moveinturret moveobjecttoend moveout movetime
+syn keyword sqfCommand      moveto movetocompleted movetofailed musicvolume name namedproperties namesound nearentities
+syn keyword sqfCommand      nearestbuilding nearestlocation nearestlocations nearestlocationwithdubbing nearestobject
+syn keyword sqfCommand      nearestobjects nearestterrainobjects nearobjects nearobjectsready nearroads nearsupplies
+syn keyword sqfCommand      neartargets needreload netid newoverlay nextmenuitemindex nextweatherchange nmenuitems not
+syn keyword sqfCommand      numberofenginesrtd numbertodate objectcurators objectfromnetid objectparent objstatus
+syn keyword sqfCommand      onbriefinggroup onbriefingnotes onbriefingplan onbriefingteamswitch oncommandmodechanged
+syn keyword sqfCommand      ondoubleclick oneachframe ongroupiconclick ongroupiconoverenter ongroupiconoverleave
+syn keyword sqfCommand      onhcgroupselectionchanged onmapsingleclick onplayerconnected onplayerdisconnected
+syn keyword sqfCommand      onpreloadfinished onpreloadstarted onshownewobject onteamswitch opencuratorinterface
+syn keyword sqfCommand      opendlcpage opengps openmap opensteamapp openyoutubevideo opfor or ordergetin overcast
+syn keyword sqfCommand      overcastforecast owner param params parsenumber parsesimplearray parsetext parsingnamespace
+syn keyword sqfCommand      particlesquality periscopeelevation pi pickweaponpool pitch pixelgrid pixelgridbase
+syn keyword sqfCommand      pixelgridnouiscale pixelh pixelw playableslotsnumber playableunits playaction playactionnow
+syn keyword sqfCommand      player playerrespawntime playerside playersnumber playgesture playmission playmove
+syn keyword sqfCommand      playmovenow playmusic playscriptedmission playsound playsound3d position
+syn keyword sqfCommand      positioncameratoworld posscreentoworld posworldtoscreen ppeffectadjust ppeffectcommit
+syn keyword sqfCommand      ppeffectcommitted ppeffectcreate ppeffectdestroy ppeffectenable ppeffectenabled
+syn keyword sqfCommand      ppeffectforceinnvg precision preloadcamera preloadobject preloadsound preloadtitleobj
+syn keyword sqfCommand      preloadtitlersc primaryweapon primaryweaponitems primaryweaponmagazine priority
+syn keyword sqfCommand      processdiarylink productversion profilename profilenamespace profilenamesteam
 syn keyword sqfCommand      progressloadingscreen progressposition progresssetposition publicvariable
 syn keyword sqfCommand      publicvariableclient publicvariableserver pushback pushbackunique putweaponpool
 syn keyword sqfCommand      queryitemspool querymagazinepool queryweaponpool rad radiochanneladd radiochannelcreate
-syn keyword sqfCommand      radiochannelremove radiochannelsetcallsign radiochannelsetlabel radiovolume rain rainbow
-syn keyword sqfCommand      random rank rankid rating rectangular registeredtasks registertask reload reloadenabled
-syn keyword sqfCommand      remotecontrol remoteexec remoteexeccall remoteexecutedowner remove3denconnection
-syn keyword sqfCommand      remove3deneventhandler remove3denlayer removeaction removeall3deneventhandlers
-syn keyword sqfCommand      removeallactions removeallassigneditems removeallcontainers removeallcuratoraddons
+syn keyword sqfCommand      radiochannelinfo radiochannelremove radiochannelsetcallsign radiochannelsetlabel
+syn keyword sqfCommand      radioenabled radiovolume rain rainbow random rank rankid rating rectangular regexfind
+syn keyword sqfCommand      regexmatch regexreplace registeredtasks registertask reload reloadenabled remotecontrol
+syn keyword sqfCommand      remoteexec remoteexeccall remoteexecutedowner remove3denconnection remove3deneventhandler
+syn keyword sqfCommand      remove3denlayer removeaction removeall3deneventhandlers removeallactions
+syn keyword sqfCommand      removeallassigneditems removeallbinocularitems removeallcontainers removeallcuratoraddons
 syn keyword sqfCommand      removeallcuratorcameraareas removeallcuratoreditingareas removealleventhandlers
 syn keyword sqfCommand      removeallhandgunitems removeallitems removeallitemswithmagazines
 syn keyword sqfCommand      removeallmissioneventhandlers removeallmpeventhandlers removeallmusiceventhandlers
-syn keyword sqfCommand      removeallownedmines removeallprimaryweaponitems removeallweapons removebackpack
-syn keyword sqfCommand      removebackpackglobal removecuratoraddons removecuratorcameraarea
-syn keyword sqfCommand      removecuratoreditableobjects removecuratoreditingarea removedrawicon removedrawlinks
+syn keyword sqfCommand      removeallownedmines removeallprimaryweaponitems removeallsecondaryweaponitems
+syn keyword sqfCommand      removealluseractioneventhandlers removeallweapons removebackpack removebackpackglobal
+syn keyword sqfCommand      removebinocularitem removecuratoraddons removecuratorcameraarea removecuratoreditableobjects
+syn keyword sqfCommand      removecuratoreditingarea removediaryrecord removediarysubject removedrawicon removedrawlinks
 syn keyword sqfCommand      removeeventhandler removefromremainscollector removegoggles removegroupicon
 syn keyword sqfCommand      removehandgunitem removeheadgear removeitem removeitemfrombackpack removeitemfromuniform
 syn keyword sqfCommand      removeitemfromvest removeitems removemagazine removemagazineglobal removemagazines
 syn keyword sqfCommand      removemagazinesturret removemagazineturret removemenuitem removemissioneventhandler
 syn keyword sqfCommand      removempeventhandler removemusiceventhandler removeownedmine removeprimaryweaponitem
 syn keyword sqfCommand      removesecondaryweaponitem removesimpletask removeswitchableunit removeteammember
-syn keyword sqfCommand      removeuniform removevest removeweapon removeweaponattachmentcargo removeweaponcargo
-syn keyword sqfCommand      removeweaponglobal removeweaponturret reportremotetarget requiredversion resetcamshake
-syn keyword sqfCommand      resetsubgroupdirection resize resources respawnvehicle restarteditorcamera reveal revealmine
-syn keyword sqfCommand      reverse reversedmousey roadat roadsconnectedto roledescription ropeattachedobjects
-syn keyword sqfCommand      ropeattachedto ropeattachenabled ropeattachto ropecreate ropecut ropedestroy ropedetach
-syn keyword sqfCommand      ropeendposition ropelength ropes ropeunwind ropeunwound rotorsforcesrtd rotorsrpmrtd round
-syn keyword sqfCommand      runinitscript safezoneh safezonew safezonewabs safezonex safezonexabs safezoney
-syn keyword sqfCommand      save3deninventory savegame saveidentity savejoysticks saveoverlay saveprofilenamespace
-syn keyword sqfCommand      savestatus savevar savingenabled say say2d say3d scopename score scoreside screenshot
-syn keyword sqfCommand      screentoworld scriptname scudstate secondaryweapon secondaryweaponitems
-syn keyword sqfCommand      secondaryweaponmagazine select selectbestplaces selectdiarysubject selectededitorobjects
-syn keyword sqfCommand      selecteditorobject selectionnames selectionposition selectleader selectmax selectmin
-syn keyword sqfCommand      selectnoplayer selectplayer selectrandom selectrandomweighted selectweapon
-syn keyword sqfCommand      selectweaponturret sendaumessage sendsimplecommand sendtask sendtaskresult sendudpmessage
-syn keyword sqfCommand      servercommand servercommandavailable servercommandexecutable servername servertime set
+syn keyword sqfCommand      removeuniform removeuseractioneventhandler removevest removeweapon
+syn keyword sqfCommand      removeweaponattachmentcargo removeweaponcargo removeweaponglobal removeweaponturret
+syn keyword sqfCommand      reportremotetarget requiredversion resetcamshake resetsubgroupdirection resize resources
+syn keyword sqfCommand      respawnvehicle restarteditorcamera reveal revealmine reverse reversedmousey roadat
+syn keyword sqfCommand      roadsconnectedto roledescription ropeattachedobjects ropeattachedto ropeattachenabled
+syn keyword sqfCommand      ropeattachto ropecreate ropecut ropedestroy ropedetach ropeendposition ropelength ropes
+syn keyword sqfCommand      ropesegments ropeunwind ropeunwound rotorsforcesrtd rotorsrpmrtd round runinitscript
+syn keyword sqfCommand      safezoneh safezonew safezonewabs safezonex safezonexabs safezoney save3deninventory savegame
+syn keyword sqfCommand      saveidentity savejoysticks saveoverlay saveprofilenamespace savestatus savevar savingenabled
+syn keyword sqfCommand      say say2d say3d scopename score scoreside screenshot screentoworld scriptname scudstate
+syn keyword sqfCommand      secondaryweapon secondaryweaponitems secondaryweaponmagazine select selectbestplaces
+syn keyword sqfCommand      selectdiarysubject selectededitorobjects selecteditorobject selectionnames selectionposition
+syn keyword sqfCommand      selectionvectordirandup selectleader selectmax selectmin selectnoplayer selectplayer
+syn keyword sqfCommand      selectrandom selectrandomweighted selectweapon selectweaponturret sendaumessage
+syn keyword sqfCommand      sendsimplecommand sendtask sendtaskresult sendudpmessage sentencesenabled servercommand
+syn keyword sqfCommand      servercommandavailable servercommandexecutable servername servernamespace servertime set
 syn keyword sqfCommand      set3denattribute set3denattributes set3dengrid set3deniconsvisible set3denlayer
 syn keyword sqfCommand      set3denlinesvisible set3denlogictype set3denmissionattribute set3denmissionattributes
 syn keyword sqfCommand      set3denmodelsvisible set3denobjecttype set3denselected setacctime setactualcollectivertd
 syn keyword sqfCommand      setairplanethrottle setairportside setammo setammocargo setammoonpylon setanimspeedcoef
 syn keyword sqfCommand      setaperture setaperturenew setarmorypoints setattributes setautonomous setbehaviour
 syn keyword sqfCommand      setbehaviourstrong setbleedingremaining setbrakesrtd setcamerainterest setcamshakedefparams
-syn keyword sqfCommand      setcamshakeparams setcamuseti setcaptive setcenterofmass setcollisionlight setcombatmode
-syn keyword sqfCommand      setcompassoscillation setconvoyseparation setcuratorcameraareaceiling setcuratorcoef
-syn keyword sqfCommand      setcuratoreditingareatype setcuratorwaypointcost setcurrentchannel setcurrenttask
-syn keyword sqfCommand      setcurrentwaypoint setcustomaimcoef setcustommissiondata setcustomsoundcontroller
-syn keyword sqfCommand      setcustomweightrtd setdamage setdammage setdate setdebriefingtext setdefaultcamera
-syn keyword sqfCommand      setdestination setdetailmapblendpars setdir setdirection setdrawicon setdriveonpath
-syn keyword sqfCommand      setdropinterval setdynamicsimulationdistance setdynamicsimulationdistancecoef seteditormode
-syn keyword sqfCommand      seteditorobjectscope seteffectcondition setenginerpmrtd setface setfaceanimation setfatigue
-syn keyword sqfCommand      setfeaturetype setflaganimationphase setflagowner setflagside setflagtexture setfog
-syn keyword sqfCommand      setforcegeneratorrtd setformation setformationtask setformdir setfriend setfromeditor
-syn keyword sqfCommand      setfsmvariable setfuel setfuelcargo setgroupicon setgroupiconparams setgroupiconsselectable
-syn keyword sqfCommand      setgroupiconsvisible setgroupid setgroupidglobal setgroupowner setgusts sethidebehind sethit
-syn keyword sqfCommand      sethitindex sethitpointdamage sethorizonparallaxcoef sethudmovementlevels setidentity
-syn keyword sqfCommand      setimportance setinfopanel setleader setlightambient setlightattenuation setlightbrightness
-syn keyword sqfCommand      setlightcolor setlightdaylight setlightflaremaxdistance setlightflaresize setlightintensity
-syn keyword sqfCommand      setlightnings setlightuseflare setlocalwindparams setmagazineturretammo setmarkeralpha
+syn keyword sqfCommand      setcamshakeparams setcamuseti setcaptive setcenterofmass setcollisionlight
+syn keyword sqfCommand      setcombatbehaviour setcombatmode setcompassoscillation setconvoyseparation setcruisecontrol
+syn keyword sqfCommand      setcuratorcameraareaceiling setcuratorcoef setcuratoreditingareatype setcuratorwaypointcost
+syn keyword sqfCommand      setcurrentchannel setcurrenttask setcurrentwaypoint setcustomaimcoef setcustommissiondata
+syn keyword sqfCommand      setcustomsoundcontroller setcustomweightrtd setdamage setdammage setdate setdebriefingtext
+syn keyword sqfCommand      setdefaultcamera setdestination setdetailmapblendpars setdiaryrecordtext
+syn keyword sqfCommand      setdiarysubjectpicture setdir setdirection setdrawicon setdriveonpath setdropinterval
+syn keyword sqfCommand      setdynamicsimulationdistance setdynamicsimulationdistancecoef seteditormode
+syn keyword sqfCommand      seteditorobjectscope seteffectcondition seteffectivecommander setenginerpmrtd setface
+syn keyword sqfCommand      setfaceanimation setfatigue setfeaturetype setflaganimationphase setflagowner setflagside
+syn keyword sqfCommand      setflagtexture setfog setforcegeneratorrtd setformation setformationtask setformdir
+syn keyword sqfCommand      setfriend setfromeditor setfsmvariable setfuel setfuelcargo setgroupicon setgroupiconparams
+syn keyword sqfCommand      setgroupiconsselectable setgroupiconsvisible setgroupid setgroupidglobal setgroupowner
+syn keyword sqfCommand      setgusts sethidebehind sethit sethitindex sethitpointdamage sethorizonparallaxcoef
+syn keyword sqfCommand      sethudmovementlevels setidentity setimportance setinfopanel setleader setlightambient
+syn keyword sqfCommand      setlightattenuation setlightbrightness setlightcolor setlightconepars setlightdaylight
+syn keyword sqfCommand      setlightflaremaxdistance setlightflaresize setlightintensity setlightir setlightnings
+syn keyword sqfCommand      setlightuseflare setlightvolumeshape setlocalwindparams setmagazineturretammo setmarkeralpha
 syn keyword sqfCommand      setmarkeralphalocal setmarkerbrush setmarkerbrushlocal setmarkercolor setmarkercolorlocal
-syn keyword sqfCommand      setmarkerdir setmarkerdirlocal setmarkerpos setmarkerposlocal setmarkershape
-syn keyword sqfCommand      setmarkershapelocal setmarkersize setmarkersizelocal setmarkertext setmarkertextlocal
-syn keyword sqfCommand      setmarkertype setmarkertypelocal setmass setmimic setmissiletarget setmissiletargetpos
-syn keyword sqfCommand      setmouseposition setmusiceffect setmusiceventhandler setname setnamesound setobjectarguments
-syn keyword sqfCommand      setobjectmaterial setobjectmaterialglobal setobjectproxy setobjecttexture
+syn keyword sqfCommand      setmarkerdir setmarkerdirlocal setmarkerpolyline setmarkerpolylinelocal setmarkerpos
+syn keyword sqfCommand      setmarkerposlocal setmarkershadow setmarkershadowlocal setmarkershape setmarkershapelocal
+syn keyword sqfCommand      setmarkersize setmarkersizelocal setmarkertext setmarkertextlocal setmarkertype
+syn keyword sqfCommand      setmarkertypelocal setmass setmimic setmissiletarget setmissiletargetpos setmouseposition
+syn keyword sqfCommand      setmusiceffect setmusiceventhandler setname setnamesound setobjectarguments
+syn keyword sqfCommand      setobjectmaterial setobjectmaterialglobal setobjectproxy setobjectscale setobjecttexture
 syn keyword sqfCommand      setobjecttextureglobal setobjectviewdistance setovercast setowner setoxygenremaining
 syn keyword sqfCommand      setparticlecircle setparticleclass setparticlefire setparticleparams setparticlerandom
 syn keyword sqfCommand      setpilotcameradirection setpilotcamerarotation setpilotcameratarget setpilotlight
-syn keyword sqfCommand      setpipeffect setpitch setplatenumber setplayable setplayerrespawntime setpos setposasl
-syn keyword sqfCommand      setposasl2 setposaslw setposatl setposition setposworld setpylonloadout setpylonspriority
-syn keyword sqfCommand      setradiomsg setrain setrainbow setrandomlip setrank setrectangular setrepaircargo
-syn keyword sqfCommand      setrotorbrakertd setshadowdistance setshotparents setside setsimpletaskalwaysvisible
-syn keyword sqfCommand      setsimpletaskcustomdata setsimpletaskdescription setsimpletaskdestination
-syn keyword sqfCommand      setsimpletasktarget setsimpletasktype setsimulweatherlayers setsize setskill setslingload
-syn keyword sqfCommand      setsoundeffect setspeaker setspeech setspeedmode setstamina setstaminascheme setstatvalue
-syn keyword sqfCommand      setsuppression setsystemofunits settargetage settaskmarkeroffset settaskresult settaskstate
-syn keyword sqfCommand      setterraingrid settext settimemultiplier settitleeffect settrafficdensity settrafficdistance
-syn keyword sqfCommand      settrafficgap settrafficspeed settriggeractivation settriggerarea settriggerstatements
+syn keyword sqfCommand      setpipeffect setpitch setplatenumber setplayable setplayerrespawntime setplayervonvolume
+syn keyword sqfCommand      setpos setposasl setposasl2 setposaslw setposatl setposition setposworld setpylonloadout
+syn keyword sqfCommand      setpylonspriority setradiomsg setrain setrainbow setrandomlip setrank setrectangular
+syn keyword sqfCommand      setrepaircargo setrotorbrakertd setshadowdistance setshotparents setside
+syn keyword sqfCommand      setsimpletaskalwaysvisible setsimpletaskcustomdata setsimpletaskdescription
+syn keyword sqfCommand      setsimpletaskdestination setsimpletasktarget setsimpletasktype setsimulweatherlayers setsize
+syn keyword sqfCommand      setskill setslingload setsoundeffect setspeaker setspeech setspeedmode setstamina
+syn keyword sqfCommand      setstaminascheme setstatvalue setsuppression setsystemofunits settargetage
+syn keyword sqfCommand      settaskmarkeroffset settaskresult settaskstate setterraingrid settext settimemultiplier
+syn keyword sqfCommand      settitleeffect settowparent settrafficdensity settrafficdistance settrafficgap
+syn keyword sqfCommand      settrafficspeed settriggeractivation settriggerarea settriggerinterval settriggerstatements
 syn keyword sqfCommand      settriggertext settriggertimeout settriggertype settype setunconscious setunitability
-syn keyword sqfCommand      setunitloadout setunitpos setunitposweak setunitrank setunitrecoilcoefficient setunittrait
-syn keyword sqfCommand      setunloadincombat setuseractiontext setusermfdtext setusermfdvalue setvariable setvectordir
-syn keyword sqfCommand      setvectordirandup setvectorup setvehicleammo setvehicleammodef setvehiclearmor
-syn keyword sqfCommand      setvehiclecargo setvehicleid setvehiclelock setvehicleposition setvehicleradar
-syn keyword sqfCommand      setvehiclereceiveremotetargets setvehiclereportownposition setvehiclereportremotetargets
-syn keyword sqfCommand      setvehicletipars setvehiclevarname setvelocity setvelocitymodelspace
-syn keyword sqfCommand      setvelocitytransformation setviewdistance setvisibleiftreecollapsed setwantedrpmrtd setwaves
-syn keyword sqfCommand      setwaypointbehaviour setwaypointcombatmode setwaypointcompletionradius
-syn keyword sqfCommand      setwaypointdescription setwaypointforcebehaviour setwaypointformation
-syn keyword sqfCommand      setwaypointhouseposition setwaypointloiterradius setwaypointloitertype setwaypointname
+syn keyword sqfCommand      setunitcombatmode setunitloadout setunitpos setunitposweak setunitrank
+syn keyword sqfCommand      setunitrecoilcoefficient setunittrait setunloadincombat setuseractiontext setusermfdtext
+syn keyword sqfCommand      setusermfdvalue setvariable setvectordir setvectordirandup setvectorup setvehicleammo
+syn keyword sqfCommand      setvehicleammodef setvehiclearmor setvehiclecargo setvehicleid setvehiclelock
+syn keyword sqfCommand      setvehicleposition setvehicleradar setvehiclereceiveremotetargets
+syn keyword sqfCommand      setvehiclereportownposition setvehiclereportremotetargets setvehicletipars setvehiclevarname
+syn keyword sqfCommand      setvelocity setvelocitymodelspace setvelocitytransformation setviewdistance
+syn keyword sqfCommand      setvisibleiftreecollapsed setwantedrpmrtd setwaves setwaypointbehaviour
+syn keyword sqfCommand      setwaypointcombatmode setwaypointcompletionradius setwaypointdescription
+syn keyword sqfCommand      setwaypointforcebehaviour setwaypointformation setwaypointhouseposition
+syn keyword sqfCommand      setwaypointloiteraltitude setwaypointloiterradius setwaypointloitertype setwaypointname
 syn keyword sqfCommand      setwaypointposition setwaypointscript setwaypointspeed setwaypointstatements
-syn keyword sqfCommand      setwaypointtimeout setwaypointtype setwaypointvisible setweaponreloadingtime setwind
-syn keyword sqfCommand      setwinddir setwindforce setwindstr setwingforcescalertd setwppos show3dicons showchat
-syn keyword sqfCommand      showcinemaborder showcommandingmenu showcompass showcuratorcompass showgps showhud
-syn keyword sqfCommand      showlegend showmap shownartillerycomputer shownchat showncompass showncuratorcompass
-syn keyword sqfCommand      showneweditorobject showngps shownhud shownmap shownpad shownradio shownscoretable
-syn keyword sqfCommand      shownuavfeed shownwarrant shownwatch showpad showradio showscoretable showsubtitles
-syn keyword sqfCommand      showuavfeed showwarrant showwatch showwaypoint showwaypoints side sideambientlife sidechat
-syn keyword sqfCommand      sideempty sideenemy sidefriendly sidelogic sideradio simpletasks simulationenabled
-syn keyword sqfCommand      simulclouddensity simulcloudocclusion simulinclouds simulweathersync sin size sizeof skill
-syn keyword sqfCommand      skillfinal skiptime sliderposition sliderrange slidersetposition slidersetrange
-syn keyword sqfCommand      slidersetspeed sliderspeed slingloadassistantshown soldiermagazines someammo sort
-syn keyword sqfCommand      soundvolume speaker speed speedmode splitstring sqrt squadparams stance startloadingscreen
-syn keyword sqfCommand      step stop stopenginertd stopped str sunormoon supportinfo suppressfor surfaceiswater
-syn keyword sqfCommand      surfacenormal surfacetype swimindepth switchableunits switchaction switchcamera
-syn keyword sqfCommand      switchgesture switchlight switchmove synchronizedobjects synchronizedtriggers
-syn keyword sqfCommand      synchronizedwaypoints synchronizeobjectsadd synchronizeobjectsremove synchronizetrigger
-syn keyword sqfCommand      synchronizewaypoint systemchat systemofunits tan targetknowledge targets targetsaggregate
-syn keyword sqfCommand      targetsquery taskalwaysvisible taskchildren taskcompleted taskcustomdata taskdescription
-syn keyword sqfCommand      taskdestination taskhint taskmarkeroffset taskparent taskresult taskstate tasktype
-syn keyword sqfCommand      teammember teamname teams teamswitch teamswitchenabled teamtype terrainintersect
-syn keyword sqfCommand      terrainintersectasl terrainintersectatasl text textlog textlogformat tg time timemultiplier
-syn keyword sqfCommand      titlecut titlefadeout titleobj titlersc titletext toarray tofixed tolower tostring toupper
-syn keyword sqfCommand      triggeractivated triggeractivation triggerammo triggerarea triggerattachedvehicle
-syn keyword sqfCommand      triggerattachobject triggerattachvehicle triggerdynamicsimulation triggerstatements
-syn keyword sqfCommand      triggertext triggertimeout triggertimeoutcurrent triggertype turretlocal turretowner
-syn keyword sqfCommand      turretunit tvadd tvclear tvcollapse tvcollapseall tvcount tvcursel tvdata tvdelete tvexpand
-syn keyword sqfCommand      tvexpandall tvpicture tvpictureright tvsetcolor tvsetcursel tvsetdata tvsetpicture
-syn keyword sqfCommand      tvsetpicturecolor tvsetpicturecolordisabled tvsetpicturecolorselected tvsetpictureright
-syn keyword sqfCommand      tvsetpicturerightcolor tvsetpicturerightcolordisabled tvsetpicturerightcolorselected
-syn keyword sqfCommand      tvsetselectcolor tvsettext tvsettooltip tvsetvalue tvsort tvsortbyvalue tvtext tvtooltip
-syn keyword sqfCommand      tvvalue type typename typeof uavcontrol uinamespace uisleep unassigncurator unassignitem
-syn keyword sqfCommand      unassignteam unassignvehicle underwater uniform uniformcontainer uniformitems
-syn keyword sqfCommand      uniformmagazines unitaddons unitaimposition unitaimpositionvisual unitbackpack unitisuav
-syn keyword sqfCommand      unitpos unitready unitrecoilcoefficient units unitsbelowheight unlinkitem unlockachievement
-syn keyword sqfCommand      unregistertask updatedrawicon updatemenuitem updateobjecttree useaiopermapobstructiontest
-syn keyword sqfCommand      useaisteeringcomponent useaudiotimeformoves userinputdisabled vectoradd vectorcos
-syn keyword sqfCommand      vectorcrossproduct vectordiff vectordir vectordirvisual vectordistance vectordistancesqr
-syn keyword sqfCommand      vectordotproduct vectorfromto vectorlinearconversion vectormagnitude vectormagnitudesqr
-syn keyword sqfCommand      vectormodeltoworld vectormodeltoworldvisual vectormultiply vectornormalized vectorup
-syn keyword sqfCommand      vectorupvisual vectorworldtomodel vectorworldtomodelvisual vehicle vehiclecargoenabled
-syn keyword sqfCommand      vehiclechat vehicleradio vehiclereceiveremotetargets vehiclereportownposition
+syn keyword sqfCommand      setwaypointtimeout setwaypointtype setwaypointvisible setweaponreloadingtime
+syn keyword sqfCommand      setweaponzeroing setwind setwinddir setwindforce setwindstr setwingforcescalertd setwppos
+syn keyword sqfCommand      show3dicons showchat showcinemaborder showcommandingmenu showcompass showcuratorcompass
+syn keyword sqfCommand      showgps showhud showlegend showmap shownartillerycomputer shownchat showncompass
+syn keyword sqfCommand      showncuratorcompass showneweditorobject showngps shownhud shownmap shownpad shownradio
+syn keyword sqfCommand      shownscoretable shownsubtitles shownuavfeed shownwarrant shownwatch showpad showradio
+syn keyword sqfCommand      showscoretable showsubtitles showuavfeed showwarrant showwatch showwaypoint showwaypoints
+syn keyword sqfCommand      side sideambientlife sidechat sideempty sideenemy sidefriendly sidelogic sideradio
+syn keyword sqfCommand      simpletasks simulationenabled simulclouddensity simulcloudocclusion simulinclouds
+syn keyword sqfCommand      simulweathersync sin size sizeof skill skillfinal skiptime sliderposition sliderrange
+syn keyword sqfCommand      slidersetposition slidersetrange slidersetspeed sliderspeed slingloadassistantshown
+syn keyword sqfCommand      soldiermagazines someammo sort soundvolume speaker speechvolume speed speedmode splitstring
+syn keyword sqfCommand      sqrt squadparams stance startloadingscreen step stop stopenginertd stopped str sunormoon
+syn keyword sqfCommand      supportinfo suppressfor surfaceiswater surfacenormal surfacetexture surfacetype swimindepth
+syn keyword sqfCommand      switchableunits switchaction switchcamera switchgesture switchlight switchmove
+syn keyword sqfCommand      synchronizedobjects synchronizedtriggers synchronizedwaypoints synchronizeobjectsadd
+syn keyword sqfCommand      synchronizeobjectsremove synchronizetrigger synchronizewaypoint systemchat systemofunits
+syn keyword sqfCommand      systemtime systemtimeutc tan targetknowledge targets targetsaggregate targetsquery
+syn keyword sqfCommand      taskalwaysvisible taskchildren taskcompleted taskcustomdata taskdescription taskdestination
+syn keyword sqfCommand      taskhint taskmarkeroffset taskname taskparent taskresult taskstate tasktype teammember
+syn keyword sqfCommand      teamname teams teamswitch teamswitchenabled teamtype terrainintersect terrainintersectasl
+syn keyword sqfCommand      terrainintersectatasl text textlog textlogformat tg time timemultiplier titlecut
+syn keyword sqfCommand      titlefadeout titleobj titlersc titletext toarray tofixed tolower toloweransi tostring
+syn keyword sqfCommand      toupper toupperansi triggeractivated triggeractivation triggerammo triggerarea
+syn keyword sqfCommand      triggerattachedvehicle triggerattachobject triggerattachvehicle triggerdynamicsimulation
+syn keyword sqfCommand      triggerinterval triggerstatements triggertext triggertimeout triggertimeoutcurrent
+syn keyword sqfCommand      triggertype trim turretlocal turretowner turretunit tvadd tvclear tvcollapse tvcollapseall
+syn keyword sqfCommand      tvcount tvcursel tvdata tvdelete tvexpand tvexpandall tvisselected tvpicture tvpictureright
+syn keyword sqfCommand      tvselection tvsetcolor tvsetcursel tvsetdata tvsetpicture tvsetpicturecolor
+syn keyword sqfCommand      tvsetpicturecolordisabled tvsetpicturecolorselected tvsetpictureright tvsetpicturerightcolor
+syn keyword sqfCommand      tvsetpicturerightcolordisabled tvsetpicturerightcolorselected tvsetselectcolor tvsetselected
+syn keyword sqfCommand      tvsettext tvsettooltip tvsetvalue tvsort tvsortall tvsortbyvalue tvsortbyvalueall tvtext
+syn keyword sqfCommand      tvtooltip tvvalue type typename typeof uavcontrol uinamespace uisleep unassigncurator
+syn keyword sqfCommand      unassignitem unassignteam unassignvehicle underwater uniform uniformcontainer uniformitems
+syn keyword sqfCommand      uniformmagazines uniqueunititems unitaddons unitaimposition unitaimpositionvisual
+syn keyword sqfCommand      unitbackpack unitcombatmode unitisuav unitpos unitready unitrecoilcoefficient units
+syn keyword sqfCommand      unitsbelowheight unitturret unlinkitem unlockachievement unregistertask updatedrawicon
+syn keyword sqfCommand      updatemenuitem updateobjecttree useaiopermapobstructiontest useaisteeringcomponent
+syn keyword sqfCommand      useaudiotimeformoves userinputdisabled values vectoradd vectorcos vectorcrossproduct
+syn keyword sqfCommand      vectordiff vectordir vectordirvisual vectordistance vectordistancesqr vectordotproduct
+syn keyword sqfCommand      vectorfromto vectorlinearconversion vectormagnitude vectormagnitudesqr vectormodeltoworld
+syn keyword sqfCommand      vectormodeltoworldvisual vectormultiply vectornormalized vectorup vectorupvisual
+syn keyword sqfCommand      vectorworldtomodel vectorworldtomodelvisual vehicle vehiclecargoenabled vehiclechat
+syn keyword sqfCommand      vehiclemoveinfo vehicleradio vehiclereceiveremotetargets vehiclereportownposition
 syn keyword sqfCommand      vehiclereportremotetargets vehicles vehiclevarname velocity velocitymodelspace
 syn keyword sqfCommand      verifysignature vest vestcontainer vestitems vestmagazines viewdistance visiblecompass
 syn keyword sqfCommand      visiblegps visiblemap visibleposition visiblepositionasl visiblescoretable visiblewatch
 syn keyword sqfCommand      waves waypointattachedobject waypointattachedvehicle waypointattachobject
 syn keyword sqfCommand      waypointattachvehicle waypointbehaviour waypointcombatmode waypointcompletionradius
 syn keyword sqfCommand      waypointdescription waypointforcebehaviour waypointformation waypointhouseposition
-syn keyword sqfCommand      waypointloiterradius waypointloitertype waypointname waypointposition waypoints
-syn keyword sqfCommand      waypointscript waypointsenableduav waypointshow waypointspeed waypointstatements
+syn keyword sqfCommand      waypointloiteraltitude waypointloiterradius waypointloitertype waypointname waypointposition
+syn keyword sqfCommand      waypoints waypointscript waypointsenableduav waypointshow waypointspeed waypointstatements
 syn keyword sqfCommand      waypointtimeout waypointtimeoutcurrent waypointtype waypointvisible weaponaccessories
-syn keyword sqfCommand      weaponaccessoriescargo weaponcargo weapondirection weaponinertia weaponlowered weapons
-syn keyword sqfCommand      weaponsitems weaponsitemscargo weaponstate weaponsturret weightrtd wfsidetext wind winddir
-syn keyword sqfCommand      windrtd windstr wingsforcesrtd worldname worldsize worldtomodel worldtomodelvisual
-syn keyword sqfCommand      worldtoscreen
+syn keyword sqfCommand      weaponaccessoriescargo weaponcargo weapondirection weaponinertia weaponlowered
+syn keyword sqfCommand      weaponreloadingtime weapons weaponsitems weaponsitemscargo weaponstate weaponsturret
+syn keyword sqfCommand      weightrtd wfsidetext wind winddir windrtd windstr wingsforcesrtd worldname worldsize
+syn keyword sqfCommand      worldtomodel worldtomodelvisual worldtoscreen
 
 syn keyword sqfKeyword      call callextension execfsm execvm exitwith scriptdone sleep spawn terminate waituntil
 

--- a/syntax/sqf.vim
+++ b/syntax/sqf.vim
@@ -422,7 +422,6 @@ syn match   sqfCommand      "#"
 syn match   sqfOperator     ">>\|&&\|||"
 syn match   sqfOperator     "[!*/%<>^=,+-]"
 syn match   sqfOperator     "&&\|||"
-syn match   sqfOperator     "[][]"
 
 " Misc
 syn keyword sqfTodo         TODO FIXME XXX contained
@@ -447,6 +446,7 @@ syn match   sqfMacro        "\<\h\w*\>\(\s\|\n\)*("me=e-1
 " Delimiters
 syn match   sqfBraces       display "[{}]"
 syn match   sqfDelimiter    "[();\\]"
+syn match   sqfDelimiter    "[][]"
 
 let b:current_syntax = "sqf"
 

--- a/syntax/sqf.vim
+++ b/syntax/sqf.vim
@@ -1,473 +1,478 @@
 " Vim syntax file
-" Language:        SQF Script (used in Bohemia Interactives ArmA/ArmA2/etc.)
-" Original Author: shreds-of-sanity@gmx.net
-" Modified By:     somebody@froghat.ca
-" Last modified for Arma 3 version 1.94
+" Language:     SQF Script (used in Bohemia Interactives ArmA/ArmA2/etc.)
+" Maintainers:  sqwishy, Jonpas
+" Author:       shreds-of-sanity@gmx.net
+" Version:      2019-08-08 [Arma 3 v1.94]
 
+" Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
   finish
 endif
 
+" SQF is case-insensitive, supportInfo returns all lower-case
 syn case ignore
 
-syn keyword     sqfCommand      # abs acctime acos action actionids actionkeys actionkeysimages actionkeysnames
-syn keyword     sqfCommand      actionkeysnamesarray actionname actionparams activateaddons activatedaddons activatekey
-syn keyword     sqfCommand      add3denconnection add3deneventhandler add3denlayer addaction addbackpack
-syn keyword     sqfCommand      addbackpackcargo addbackpackcargoglobal addbackpackglobal addcamshake addcuratoraddons
-syn keyword     sqfCommand      addcuratorcameraarea addcuratoreditableobjects addcuratoreditingarea addcuratorpoints
-syn keyword     sqfCommand      addeditorobject addeventhandler addforce addforcegeneratorrtd addgoggles addgroupicon
-syn keyword     sqfCommand      addhandgunitem addheadgear additem additemcargo additemcargoglobal additempool
-syn keyword     sqfCommand      additemtobackpack additemtouniform additemtovest addlivestats addmagazine
-syn keyword     sqfCommand      addmagazineammocargo addmagazinecargo addmagazinecargoglobal addmagazineglobal
-syn keyword     sqfCommand      addmagazinepool addmagazines addmagazineturret addmenu addmenuitem
-syn keyword     sqfCommand      addmissioneventhandler addmpeventhandler addmusiceventhandler addownedmine
-syn keyword     sqfCommand      addplayerscores addprimaryweaponitem addpublicvariableeventhandler addrating
-syn keyword     sqfCommand      addresources addscore addscoreside addsecondaryweaponitem addswitchableunit
-syn keyword     sqfCommand      addteammember addtoremainscollector addtorque adduniform addvehicle addvest addwaypoint
-syn keyword     sqfCommand      addweapon addweaponcargo addweaponcargoglobal addweaponglobal addweaponitem
-syn keyword     sqfCommand      addweaponpool addweaponturret addweaponwithattachmentscargo
-syn keyword     sqfCommand      addweaponwithattachmentscargoglobal admin agent agents agltoasl aimedattarget aimpos
-syn keyword     sqfCommand      airdensitycurvertd airdensityrtd airplanethrottle airportside aisfinishheal alive
-syn keyword     sqfCommand      all3denentities allairports allcontrols allcurators allcutlayers alldead alldeadmen
-syn keyword     sqfCommand      alldisplays allgroups allmapmarkers allmines allmissionobjects allow3dmode
-syn keyword     sqfCommand      allowcrewinimmobile allowcuratorlogicignoreareas allowdamage allowdammage
-syn keyword     sqfCommand      allowfileoperations allowfleeing allowgetin allowsprint allplayers allsimpleobjects
-syn keyword     sqfCommand      allsites allturrets allunits allunitsuav allvariables ammo ammoonpylon and animate
-syn keyword     sqfCommand      animatebay animatedoor animatepylon animatesource animationnames animationphase
-syn keyword     sqfCommand      animationsourcephase animationstate append apply armorypoints arrayintersect asin
-syn keyword     sqfCommand      asltoagl asltoatl assert assignascargo assignascargoindex assignascommander
-syn keyword     sqfCommand      assignasdriver assignasgunner assignasturret assigncurator assignedcargo
-syn keyword     sqfCommand      assignedcommander assigneddriver assignedgunner assigneditems assignedtarget
-syn keyword     sqfCommand      assignedteam assignedvehicle assignedvehiclerole assignitem assignteam assigntoairport
-syn keyword     sqfCommand      atan atan2 atg atltoasl attachedobject attachedobjects attachedto attachobject attachto
-syn keyword     sqfCommand      attackenabled backpack backpackcargo backpackcontainer backpackitems backpackmagazines
-syn keyword     sqfCommand      backpackspacefor behaviour benchmark bezierinterpolation binocular blufor boundingbox
-syn keyword     sqfCommand      boundingboxreal boundingcenter breakout breakto briefingname buildingexit buildingpos
-syn keyword     sqfCommand      buldozer_enableroaddiag buldozer_isenabledroaddiag buldozer_loadnewroads
-syn keyword     sqfCommand      buldozer_reloadopermap buttonaction buttonsetaction cadetmode calculatepath
-syn keyword     sqfCommand      calculateplayervisibilitybyfriendly camcommand camcommit camcommitprepared camcommitted
-syn keyword     sqfCommand      camconstuctionsetparams camcreate camdestroy cameraeffect cameraeffectenablehud
-syn keyword     sqfCommand      camerainterest cameraon cameraview campaignconfigfile campreload campreloaded
-syn keyword     sqfCommand      campreparebank campreparedir campreparedive campreparefocus campreparefov
-syn keyword     sqfCommand      campreparefovrange campreparepos campreparerelpos campreparetarget camsetbank camsetdir
-syn keyword     sqfCommand      camsetdive camsetfocus camsetfov camsetfovrange camsetpos camsetrelpos camsettarget
-syn keyword     sqfCommand      camtarget camusenvg canadd canadditemtobackpack canadditemtouniform canadditemtovest
-syn keyword     sqfCommand      cancelsimpletaskdestination canfire canmove canslingload canstand cansuspend
-syn keyword     sqfCommand      cantriggerdynamicsimulation canunloadincombat canvehiclecargo captive captivenum
-syn keyword     sqfCommand      cbchecked cbsetchecked ceil channelenabled cheatsenabled checkaifeature checkvisibility
-syn keyword     sqfCommand      classname clear3denattribute clear3deninventory clearallitemsfrombackpack
-syn keyword     sqfCommand      clearbackpackcargo clearbackpackcargoglobal clearforcesrtd cleargroupicons
-syn keyword     sqfCommand      clearitemcargo clearitemcargoglobal clearitempool clearmagazinecargo
-syn keyword     sqfCommand      clearmagazinecargoglobal clearmagazinepool clearoverlay clearradio clearweaponcargo
-syn keyword     sqfCommand      clearweaponcargoglobal clearweaponpool clientowner closedialog closedisplay closeoverlay
-syn keyword     sqfCommand      collapseobjecttree collect3denhistory collectivertd combatmode commandartilleryfire
-syn keyword     sqfCommand      commandchat commander commandfire commandfollow commandgetout commandingmenu commandmove
-syn keyword     sqfCommand      commandradio commandstop commandsuppressivefire commandtarget commandwatch comment
-syn keyword     sqfCommand      commitoverlay completedfsm composetext configclasses configfile confighierarchy
-syn keyword     sqfCommand      configname confignull configproperties configsourceaddonlist configsourcemod
-syn keyword     sqfCommand      configsourcemodlist confirmsensortarget connectterminaltouav controlsgroupctrl
-syn keyword     sqfCommand      copyfromclipboard copytoclipboard copywaypoints cos countenemy countfriendly countside
-syn keyword     sqfCommand      counttype countunknown create3dencomposition create3denentity createagent createcenter
-syn keyword     sqfCommand      createdialog creatediarylink creatediaryrecord creatediarysubject createdisplay
-syn keyword     sqfCommand      creategeardialog creategroup createguardedpoint createlocation createmarker
-syn keyword     sqfCommand      createmarkerlocal createmenu createmine createmissiondisplay creatempcampaigndisplay
-syn keyword     sqfCommand      createsimpleobject createsimpletask createsite createsoundsource createtask createteam
-syn keyword     sqfCommand      createtrigger createunit createvehicle createvehiclecrew createvehiclelocal crew
-syn keyword     sqfCommand      ctaddheader ctaddrow ctclear ctcursel ctdata ctfindheaderrows ctfindrowheader
-syn keyword     sqfCommand      ctheadercontrols ctheadercount ctremoveheaders ctremoverows ctrlactivate
-syn keyword     sqfCommand      ctrladdeventhandler ctrlangle ctrlanimatemodel ctrlanimationphasemodel
-syn keyword     sqfCommand      ctrlautoscrolldelay ctrlautoscrollrewind ctrlautoscrollspeed ctrlchecked ctrlclassname
-syn keyword     sqfCommand      ctrlcommit ctrlcommitted ctrlcreate ctrldelete ctrlenable ctrlenabled ctrlfade
-syn keyword     sqfCommand      ctrlhtmlloaded ctrlidc ctrlidd ctrlmapanimadd ctrlmapanimclear ctrlmapanimcommit
-syn keyword     sqfCommand      ctrlmapanimdone ctrlmapcursor ctrlmapmouseover ctrlmapscale ctrlmapscreentoworld
-syn keyword     sqfCommand      ctrlmapworldtoscreen ctrlmodel ctrlmodeldirandup ctrlmodelscale ctrlparent
-syn keyword     sqfCommand      ctrlparentcontrolsgroup ctrlposition ctrlremovealleventhandlers ctrlremoveeventhandler
-syn keyword     sqfCommand      ctrlscale ctrlsetactivecolor ctrlsetangle ctrlsetautoscrolldelay ctrlsetautoscrollrewind
-syn keyword     sqfCommand      ctrlsetautoscrollspeed ctrlsetbackgroundcolor ctrlsetchecked ctrlsetdisabledcolor
-syn keyword     sqfCommand      ctrlseteventhandler ctrlsetfade ctrlsetfocus ctrlsetfont ctrlsetfonth1 ctrlsetfonth1b
-syn keyword     sqfCommand      ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3 ctrlsetfonth3b ctrlsetfonth4 ctrlsetfonth4b
-syn keyword     sqfCommand      ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6 ctrlsetfonth6b ctrlsetfontheight
-syn keyword     sqfCommand      ctrlsetfontheighth1 ctrlsetfontheighth2 ctrlsetfontheighth3 ctrlsetfontheighth4
-syn keyword     sqfCommand      ctrlsetfontheighth5 ctrlsetfontheighth6 ctrlsetfontheightsecondary ctrlsetfontp
-syn keyword     sqfCommand      ctrlsetfontpb ctrlsetfontsecondary ctrlsetforegroundcolor ctrlsetmodel
-syn keyword     sqfCommand      ctrlsetmodeldirandup ctrlsetmodelscale ctrlsetpixelprecision ctrlsetposition
-syn keyword     sqfCommand      ctrlsetpositionh ctrlsetpositionw ctrlsetpositionx ctrlsetpositiony ctrlsetscale
-syn keyword     sqfCommand      ctrlsetstructuredtext ctrlsettext ctrlsettextcolor ctrlsettextcolorsecondary
-syn keyword     sqfCommand      ctrlsettextsecondary ctrlsettooltip ctrlsettooltipcolorbox ctrlsettooltipcolorshade
-syn keyword     sqfCommand      ctrlsettooltipcolortext ctrlshow ctrlshown ctrltext ctrltextheight ctrltextsecondary
-syn keyword     sqfCommand      ctrltextwidth ctrltype ctrlvisible ctrowcontrols ctrowcount ctsetcursel ctsetdata
-syn keyword     sqfCommand      ctsetheadertemplate ctsetrowtemplate ctsetvalue ctvalue curatoraddons curatorcamera
-syn keyword     sqfCommand      curatorcameraarea curatorcameraareaceiling curatorcoef curatoreditableobjects
-syn keyword     sqfCommand      curatoreditingarea curatoreditingareatype curatormouseover curatorpoints
-syn keyword     sqfCommand      curatorregisteredobjects curatorselected curatorwaypointcost current3denoperation
-syn keyword     sqfCommand      currentchannel currentcommand currentmagazine currentmagazinedetail
-syn keyword     sqfCommand      currentmagazinedetailturret currentmagazineturret currentmuzzle currentnamespace
-syn keyword     sqfCommand      currenttask currenttasks currentthrowable currentvisionmode currentwaypoint
-syn keyword     sqfCommand      currentweapon currentweaponmode currentweaponturret currentzeroing cursorobject
-syn keyword     sqfCommand      cursortarget customchat customradio customwaypointposition cutfadeout cutobj cutrsc
-syn keyword     sqfCommand      cuttext damage date datetonumber daytime deactivatekey debriefingtext debugfsm debuglog
-syn keyword     sqfCommand      decaygraphvalues deg delete3denentities deleteat deletecenter deletecollection
-syn keyword     sqfCommand      deleteeditorobject deletegroup deletegroupwhenempty deleteidentity deletelocation
-syn keyword     sqfCommand      deletemarker deletemarkerlocal deleterange deleteresources deletesite deletestatus
-syn keyword     sqfCommand      deleteteam deletevehicle deletevehiclecrew deletewaypoint detach detectedmines
-syn keyword     sqfCommand      diag_activemissionfsms diag_activescripts diag_activesqfscripts diag_activesqsscripts
-syn keyword     sqfCommand      diag_codeperformance diag_dynamicsimulationend diag_fps diag_fpsmin diag_frameno
-syn keyword     sqfCommand      diag_lightnewload diag_log diag_setlightnew diag_ticktime dialog diarysubjectexists
-syn keyword     sqfCommand      didjip didjipowner difficulty difficultyenabled difficultyenabledrtd difficultyoption
-syn keyword     sqfCommand      direction directsay disableai disablecollisionwith disableconversation
-syn keyword     sqfCommand      disabledebriefingstats disablemapindicators disablenvgequipment disableremotesensors
-syn keyword     sqfCommand      disableserialization disabletiequipment disableuavconnectability disableuserinput
-syn keyword     sqfCommand      displayaddeventhandler displayctrl displayparent displayremovealleventhandlers
-syn keyword     sqfCommand      displayremoveeventhandler displayseteventhandler dissolveteam distance distance2d
-syn keyword     sqfCommand      distancesqr distributionregion do3denaction doartilleryfire dofire dofollow dogetout
-syn keyword     sqfCommand      domove doorphase dostop dosuppressivefire dotarget dowatch drawarrow drawellipse
-syn keyword     sqfCommand      drawicon drawicon3d drawline drawline3d drawlink drawlocation drawpolygon drawrectangle
-syn keyword     sqfCommand      drawtriangle driver drop dynamicsimulationdistance dynamicsimulationdistancecoef
-syn keyword     sqfCommand      dynamicsimulationenabled dynamicsimulationsystemenabled echo edit3denmissionattributes
-syn keyword     sqfCommand      editobject editorseteventhandler effectivecommander emptypositions enableai
-syn keyword     sqfCommand      enableaifeature enableaimprecision enableattack enableaudiofeature enableautostartuprtd
-syn keyword     sqfCommand      enableautotrimrtd enablecamshake enablecaustics enablechannel enablecollisionwith
-syn keyword     sqfCommand      enablecopilot enabledebriefingstats enablediaglegend enabledynamicsimulation
-syn keyword     sqfCommand      enabledynamicsimulationsystem enableenddialog enableengineartillery enableenvironment
-syn keyword     sqfCommand      enablefatigue enablegunlights enableinfopanelcomponent enableirlasers enablemimics
-syn keyword     sqfCommand      enablepersonturret enableradio enablereload enableropeattach enablesatnormalondetail
-syn keyword     sqfCommand      enablesaving enablesentences enablesimulation enablesimulationglobal enablestamina
-syn keyword     sqfCommand      enablestressdamage enableteamswitch enabletraffic enableuavconnectability
-syn keyword     sqfCommand      enableuavwaypoints enablevehiclecargo enablevehiclesensor enableweapondisassembly endl
-syn keyword     sqfCommand      endloadingscreen endmission engineon enginesisonrtd enginespowerrtd enginesrpmrtd
-syn keyword     sqfCommand      enginestorquertd entities environmentenabled estimatedendservertime estimatedtimeleft
-syn keyword     sqfCommand      evalobjectargument everybackpack everycontainer exec execeditorscript exit exp
-syn keyword     sqfCommand      expecteddestination exportjipmessages eyedirection eyepos face faction fademusic
-syn keyword     sqfCommand      faderadio fadesound fadespeech failmission fillweaponsfrompool find findcover
-syn keyword     sqfCommand      finddisplay findeditorobject findemptyposition findemptypositionready findif
-syn keyword     sqfCommand      findnearestenemy finishmissioninit finite fire fireattarget firstbackpack flag
-syn keyword     sqfCommand      flaganimationphase flagowner flagside flagtexture fleeing floor flyinheight
-syn keyword     sqfCommand      flyinheightasl fog fogforecast fogparams forceadduniform forceatpositionrtd forcedmap
-syn keyword     sqfCommand      forceend forceflagtexture forcefollowroad forcegeneratorrtd forcemap forcerespawn
-syn keyword     sqfCommand      forcespeed forcewalk forceweaponfire forceweatherchange foreachmember foreachmemberagent
-syn keyword     sqfCommand      foreachmemberteam forgettarget format formation formationdirection formationleader
-syn keyword     sqfCommand      formationmembers formationposition formationtask formattext formleader freelook
-syn keyword     sqfCommand      fromeditor fuel fullcrew gearidcammocount gearslotammocount gearslotdata
-syn keyword     sqfCommand      get3denactionstate get3denattribute get3dencamera get3denconnections get3denentity
-syn keyword     sqfCommand      get3denentityid get3dengrid get3deniconsvisible get3denlayerentities get3denlinesvisible
-syn keyword     sqfCommand      get3denmissionattribute get3denmouseover get3denselected getaimingcoef
-syn keyword     sqfCommand      getallenvsoundcontrollers getallhitpointsdamage getallownedmines getallsoundcontrollers
-syn keyword     sqfCommand      getammocargo getanimaimprecision getanimspeedcoef getarray getartilleryammo
-syn keyword     sqfCommand      getartillerycomputersettings getartilleryeta getassignedcuratorlogic
-syn keyword     sqfCommand      getassignedcuratorunit getaudiooptionvolumes getbackpackcargo getbleedingremaining
-syn keyword     sqfCommand      getburningvalue getcalculateplayervisibilitybyfriendly getcameraviewdirection
-syn keyword     sqfCommand      getcargoindex getcenterofmass getclientstate getclientstatenumber
-syn keyword     sqfCommand      getcompatiblepylonmagazines getconnecteduav getcontainermaxload getcursorobjectparams
-syn keyword     sqfCommand      getcustomaimcoef getcustomsoundcontroller getcustomsoundcontrollercount getdammage
-syn keyword     sqfCommand      getdescription getdir getdirvisual getdlcassetsusage getdlcassetsusagebyname getdlcs
-syn keyword     sqfCommand      getdlcusagetime geteditorcamera geteditormode geteditorobjectscope getelevationoffset
-syn keyword     sqfCommand      getenginetargetrpmrtd getenvsoundcontroller getfatigue getfieldmanualstartpage
-syn keyword     sqfCommand      getforcedflagtexture getfriend getfsmvariable getfuelcargo getgraphvalues getgroupicon
-syn keyword     sqfCommand      getgroupiconparams getgroupicons gethidefrom gethit gethitindex gethitpointdamage
-syn keyword     sqfCommand      getitemcargo getmagazinecargo getmarkercolor getmarkerpos getmarkersize getmarkertype
-syn keyword     sqfCommand      getmass getmissionconfig getmissionconfigvalue getmissiondlcs getmissionlayerentities
-syn keyword     sqfCommand      getmissionlayers getmodelinfo getmouseposition getmusicplayedtime getnumber
-syn keyword     sqfCommand      getobjectargument getobjectchildren getobjectdlc getobjectmaterials getobjectproxy
-syn keyword     sqfCommand      getobjecttextures getobjecttype getobjectviewdistance getoxygenremaining
-syn keyword     sqfCommand      getpersonuseddlcs getpilotcameradirection getpilotcameraposition getpilotcamerarotation
-syn keyword     sqfCommand      getpilotcameratarget getplatenumber getplayerchannel getplayerscores getplayeruid getpos
-syn keyword     sqfCommand      getposasl getposaslvisual getposaslw getposatl getposatlvisual getposvisual getposworld
-syn keyword     sqfCommand      getpylonmagazines getreldir getrelpos getremotesensorsdisabled getrepaircargo
-syn keyword     sqfCommand      getresolution getrotorbrakertd getshadowdistance getshotparents getslingload
-syn keyword     sqfCommand      getsoundcontroller getsoundcontrollerresult getspeed getstamina getstatvalue
-syn keyword     sqfCommand      getsubtitleoptions getsuppression getterraingrid getterrainheightasl gettext
-syn keyword     sqfCommand      gettotaldlcusagetime gettrimoffsetrtd getunitloadout getunittrait getusermfdtext
-syn keyword     sqfCommand      getusermfdvalue getvariable getvehiclecargo getweaponcargo getweaponsway
-syn keyword     sqfCommand      getwingsorientationrtd getwingspositionrtd getwppos glanceat globalchat globalradio
-syn keyword     sqfCommand      goggles goto group groupchat groupfromnetid groupiconselectable groupiconsvisible
-syn keyword     sqfCommand      groupid groupowner groupradio groupselectedunits groupselectunit gunner gusts halt
-syn keyword     sqfCommand      handgunitems handgunmagazine handgunweapon handshit hasinterface haspilotcamera
-syn keyword     sqfCommand      hasweapon hcallgroups hcgroupparams hcleader hcremoveallgroups hcremovegroup hcselected
-syn keyword     sqfCommand      hcselectgroup hcsetgroup hcshowbar hcshownbar headgear hidebody hideobject
-syn keyword     sqfCommand      hideobjectglobal hideselection hint hintc hintcadet hintsilent hmd hostmission htmlload
-syn keyword     sqfCommand      hudmovementlevels humidity image importallgroups importance in inarea inareaarray
-syn keyword     sqfCommand      incapacitatedstate inflame inflamed infopanel infopanelcomponentenabled
-syn keyword     sqfCommand      infopanelcomponents infopanels ingameuiseteventhandler inheritsfrom initambientlife
-syn keyword     sqfCommand      inpolygon inputaction inrangeofartillery inserteditorobject intersect is3den
-syn keyword     sqfCommand      is3denmultiplayer isabletobreathe isagent isaimprecisionenabled isarray isautohoveron
-syn keyword     sqfCommand      isautonomous isautostartupenabledrtd isautotest isautotrimonrtd isbleeding isburning
-syn keyword     sqfCommand      isclass iscollisionlighton iscopilotenabled isdamageallowed isdedicated isdlcavailable
-syn keyword     sqfCommand      isengineon isequalto isequaltype isequaltypeall isequaltypeany isequaltypearray
-syn keyword     sqfCommand      isequaltypeparams isfilepatchingenabled isflashlighton isflatempty isforcedwalk
-syn keyword     sqfCommand      isformationleader isgroupdeletedwhenempty ishidden isinremainscollector
-syn keyword     sqfCommand      isinstructorfigureenabled isirlaseron iskeyactive iskindof islaseron islighton
-syn keyword     sqfCommand      islocalized ismanualfire ismarkedforcollection ismultiplayer ismultiplayersolo isnil
-syn keyword     sqfCommand      isnull isnumber isobjecthidden isobjectrtd isonroad ispipenabled isplayer isrealtime
-syn keyword     sqfCommand      isremoteexecuted isremoteexecutedjip issensortargetconfirmed isserver isshowing3dicons
-syn keyword     sqfCommand      issimpleobject issprintallowed isstaminaenabled issteammission isstreamfriendlyuienabled
-syn keyword     sqfCommand      isstressdamageenabled istext istouchingground isturnedout istuthintsenabled
-syn keyword     sqfCommand      isuavconnectable isuavconnected isuicontext isuniformallowed isvehiclecargo
-syn keyword     sqfCommand      isvehicleradaron isvehiclesensorenabled iswalking isweapondeployed isweaponrested
-syn keyword     sqfCommand      itemcargo items itemswithmagazines join joinas joinassilent joinsilent joinstring
-syn keyword     sqfCommand      kbadddatabase kbadddatabasetargets kbaddtopic kbhastopic kbreact kbremovetopic kbtell
-syn keyword     sqfCommand      kbwassaid keyimage keyname knowsabout land landat landresult language lasertarget lbadd
-syn keyword     sqfCommand      lbclear lbcolor lbcolorright lbcursel lbdata lbdelete lbisselected lbpicture
-syn keyword     sqfCommand      lbpictureright lbselection lbsetcolor lbsetcolorright lbsetcursel lbsetdata lbsetpicture
-syn keyword     sqfCommand      lbsetpicturecolor lbsetpicturecolordisabled lbsetpicturecolorselected lbsetpictureright
-syn keyword     sqfCommand      lbsetpicturerightcolor lbsetpicturerightcolordisabled lbsetpicturerightcolorselected
-syn keyword     sqfCommand      lbsetselectcolor lbsetselectcolorright lbsetselected lbsettext lbsettextright
-syn keyword     sqfCommand      lbsettooltip lbsetvalue lbsize lbsort lbsortbyvalue lbtext lbtextright lbvalue leader
-syn keyword     sqfCommand      leaderboarddeinit leaderboardgetrows leaderboardinit leaderboardrequestrowsfriends
-syn keyword     sqfCommand      leaderboardrequestrowsglobal leaderboardrequestrowsglobalarounduser
-syn keyword     sqfCommand      leaderboardsrequestuploadscore leaderboardsrequestuploadscorekeepbest leaderboardstate
-syn keyword     sqfCommand      leavevehicle librarycredits librarydisclaimers lifestate lightattachobject
-syn keyword     sqfCommand      lightdetachobject lightison lightnings limitspeed linearconversion linebreak
-syn keyword     sqfCommand      lineintersects lineintersectsobjs lineintersectssurfaces lineintersectswith linkitem
-syn keyword     sqfCommand      list listobjects listremotetargets listvehiclesensors ln lnbaddarray lnbaddcolumn
-syn keyword     sqfCommand      lnbaddrow lnbclear lnbcolor lnbcolorright lnbcurselrow lnbdata lnbdeletecolumn
-syn keyword     sqfCommand      lnbdeleterow lnbgetcolumnsposition lnbpicture lnbpictureright lnbsetcolor
-syn keyword     sqfCommand      lnbsetcolorright lnbsetcolumnspos lnbsetcurselrow lnbsetdata lnbsetpicture
-syn keyword     sqfCommand      lnbsetpicturecolor lnbsetpicturecolorright lnbsetpicturecolorselected
-syn keyword     sqfCommand      lnbsetpicturecolorselectedright lnbsetpictureright lnbsettext lnbsettextright
-syn keyword     sqfCommand      lnbsettooltip lnbsetvalue lnbsize lnbsort lnbsortbyvalue lnbtext lnbtextright lnbvalue
-syn keyword     sqfCommand      load loadabs loadbackpack loadfile loadgame loadidentity loadmagazine loadoverlay
-syn keyword     sqfCommand      loadstatus loaduniform loadvest local localize locationposition lock lockcamerato
-syn keyword     sqfCommand      lockcargo lockdriver locked lockedcargo lockeddriver lockedturret lockidentity
-syn keyword     sqfCommand      lockturret lockwp log logentities lognetwork lognetworkterminate lookat lookatpos
-syn keyword     sqfCommand      magazinecargo magazines magazinesallturrets magazinesammo magazinesammocargo
-syn keyword     sqfCommand      magazinesammofull magazinesdetail magazinesdetailbackpack magazinesdetailuniform
-syn keyword     sqfCommand      magazinesdetailvest magazinesturret magazineturretammo mapanimadd mapanimclear
-syn keyword     sqfCommand      mapanimcommit mapanimdone mapcenteroncamera mapgridposition markasfinishedonsteam
-syn keyword     sqfCommand      markeralpha markerbrush markercolor markerdir markerpos markershape markersize
-syn keyword     sqfCommand      markertext markertype matrixmultiply matrixtranspose max members menuaction menuadd
-syn keyword     sqfCommand      menuchecked menuclear menucollapse menudata menudelete menuenable menuenabled menuexpand
-syn keyword     sqfCommand      menuhover menupicture menusetaction menusetcheck menusetdata menusetpicture menusetvalue
-syn keyword     sqfCommand      menushortcut menushortcuttext menusize menusort menutext menuurl menuvalue min
-syn keyword     sqfCommand      mineactive minedetectedby missiletarget missiletargetpos missionconfigfile
-syn keyword     sqfCommand      missiondifficulty missionname missionnamespace missionstart missionversion mod
-syn keyword     sqfCommand      modeltoworld modeltoworldvisual modeltoworldvisualworld modeltoworldworld modparams
-syn keyword     sqfCommand      moonintensity moonphase morale move move3dencamera moveinany moveincargo moveincommander
-syn keyword     sqfCommand      moveindriver moveingunner moveinturret moveobjecttoend moveout movetime moveto
-syn keyword     sqfCommand      movetocompleted movetofailed musicvolume name namesound nearentities nearestbuilding
-syn keyword     sqfCommand      nearestlocation nearestlocations nearestlocationwithdubbing nearestobject nearestobjects
-syn keyword     sqfCommand      nearestterrainobjects nearobjects nearobjectsready nearroads nearsupplies neartargets
-syn keyword     sqfCommand      needreload netid newoverlay nextmenuitemindex nextweatherchange nmenuitems not
-syn keyword     sqfCommand      numberofenginesrtd numbertodate objectcurators objectfromnetid objectparent objstatus
-syn keyword     sqfCommand      onbriefinggroup onbriefingnotes onbriefingplan onbriefingteamswitch oncommandmodechanged
-syn keyword     sqfCommand      ondoubleclick oneachframe ongroupiconclick ongroupiconoverenter ongroupiconoverleave
-syn keyword     sqfCommand      onhcgroupselectionchanged onmapsingleclick onplayerconnected onplayerdisconnected
-syn keyword     sqfCommand      onpreloadfinished onpreloadstarted onshownewobject onteamswitch opencuratorinterface
-syn keyword     sqfCommand      opendlcpage openmap opensteamapp openyoutubevideo opfor or ordergetin overcast
-syn keyword     sqfCommand      overcastforecast owner param params parsenumber parsesimplearray parsetext
-syn keyword     sqfCommand      parsingnamespace particlesquality pi pickweaponpool pitch pixelgrid pixelgridbase
-syn keyword     sqfCommand      pixelgridnouiscale pixelh pixelw playableslotsnumber playableunits playaction
-syn keyword     sqfCommand      playactionnow player playerrespawntime playerside playersnumber playgesture playmission
-syn keyword     sqfCommand      playmove playmovenow playmusic playscriptedmission playsound playsound3d position
-syn keyword     sqfCommand      positioncameratoworld posscreentoworld posworldtoscreen ppeffectadjust ppeffectcommit
-syn keyword     sqfCommand      ppeffectcommitted ppeffectcreate ppeffectdestroy ppeffectenable ppeffectenabled
-syn keyword     sqfCommand      ppeffectforceinnvg precision preloadcamera preloadobject preloadsound preloadtitleobj
-syn keyword     sqfCommand      preloadtitlersc primaryweapon primaryweaponitems primaryweaponmagazine priority
-syn keyword     sqfCommand      processdiarylink productversion profilename profilenamespace profilenamesteam
-syn keyword     sqfCommand      progressloadingscreen progressposition progresssetposition publicvariable
-syn keyword     sqfCommand      publicvariableclient publicvariableserver pushback pushbackunique putweaponpool
-syn keyword     sqfCommand      queryitemspool querymagazinepool queryweaponpool rad radiochanneladd radiochannelcreate
-syn keyword     sqfCommand      radiochannelremove radiochannelsetcallsign radiochannelsetlabel radiovolume rain rainbow
-syn keyword     sqfCommand      random rank rankid rating rectangular registeredtasks registertask reload reloadenabled
-syn keyword     sqfCommand      remotecontrol remoteexec remoteexeccall remoteexecutedowner remove3denconnection
-syn keyword     sqfCommand      remove3deneventhandler remove3denlayer removeaction removeall3deneventhandlers
-syn keyword     sqfCommand      removeallactions removeallassigneditems removeallcontainers removeallcuratoraddons
-syn keyword     sqfCommand      removeallcuratorcameraareas removeallcuratoreditingareas removealleventhandlers
-syn keyword     sqfCommand      removeallhandgunitems removeallitems removeallitemswithmagazines
-syn keyword     sqfCommand      removeallmissioneventhandlers removeallmpeventhandlers removeallmusiceventhandlers
-syn keyword     sqfCommand      removeallownedmines removeallprimaryweaponitems removeallweapons removebackpack
-syn keyword     sqfCommand      removebackpackglobal removecuratoraddons removecuratorcameraarea
-syn keyword     sqfCommand      removecuratoreditableobjects removecuratoreditingarea removedrawicon removedrawlinks
-syn keyword     sqfCommand      removeeventhandler removefromremainscollector removegoggles removegroupicon
-syn keyword     sqfCommand      removehandgunitem removeheadgear removeitem removeitemfrombackpack removeitemfromuniform
-syn keyword     sqfCommand      removeitemfromvest removeitems removemagazine removemagazineglobal removemagazines
-syn keyword     sqfCommand      removemagazinesturret removemagazineturret removemenuitem removemissioneventhandler
-syn keyword     sqfCommand      removempeventhandler removemusiceventhandler removeownedmine removeprimaryweaponitem
-syn keyword     sqfCommand      removesecondaryweaponitem removesimpletask removeswitchableunit removeteammember
-syn keyword     sqfCommand      removeuniform removevest removeweapon removeweaponattachmentcargo removeweaponcargo
-syn keyword     sqfCommand      removeweaponglobal removeweaponturret reportremotetarget requiredversion resetcamshake
-syn keyword     sqfCommand      resetsubgroupdirection resize resources respawnvehicle restarteditorcamera reveal
-syn keyword     sqfCommand      revealmine reverse reversedmousey roadat roadsconnectedto roledescription
-syn keyword     sqfCommand      ropeattachedobjects ropeattachedto ropeattachenabled ropeattachto ropecreate ropecut
-syn keyword     sqfCommand      ropedestroy ropedetach ropeendposition ropelength ropes ropeunwind ropeunwound
-syn keyword     sqfCommand      rotorsforcesrtd rotorsrpmrtd round runinitscript safezoneh safezonew safezonewabs
-syn keyword     sqfCommand      safezonex safezonexabs safezoney save3deninventory savegame saveidentity savejoysticks
-syn keyword     sqfCommand      saveoverlay saveprofilenamespace savestatus savevar savingenabled say say2d say3d
-syn keyword     sqfCommand      scopename score scoreside screenshot screentoworld scriptname scudstate secondaryweapon
-syn keyword     sqfCommand      secondaryweaponitems secondaryweaponmagazine select selectbestplaces selectdiarysubject
-syn keyword     sqfCommand      selectededitorobjects selecteditorobject selectionnames selectionposition selectleader
-syn keyword     sqfCommand      selectmax selectmin selectnoplayer selectplayer selectrandom selectrandomweighted
-syn keyword     sqfCommand      selectweapon selectweaponturret sendaumessage sendsimplecommand sendtask sendtaskresult
-syn keyword     sqfCommand      sendudpmessage servercommand servercommandavailable servercommandexecutable servername
-syn keyword     sqfCommand      servertime set set3denattribute set3denattributes set3dengrid set3deniconsvisible
-syn keyword     sqfCommand      set3denlayer set3denlinesvisible set3denlogictype set3denmissionattribute
-syn keyword     sqfCommand      set3denmissionattributes set3denmodelsvisible set3denobjecttype set3denselected
-syn keyword     sqfCommand      setacctime setactualcollectivertd setairplanethrottle setairportside setammo
-syn keyword     sqfCommand      setammocargo setammoonpylon setanimspeedcoef setaperture setaperturenew setarmorypoints
-syn keyword     sqfCommand      setattributes setautonomous setbehaviour setbehaviourstrong setbleedingremaining
-syn keyword     sqfCommand      setbrakesrtd setcamerainterest setcamshakedefparams setcamshakeparams setcamuseti
-syn keyword     sqfCommand      setcaptive setcenterofmass setcollisionlight setcombatmode setcompassoscillation
-syn keyword     sqfCommand      setconvoyseparation setcuratorcameraareaceiling setcuratorcoef setcuratoreditingareatype
-syn keyword     sqfCommand      setcuratorwaypointcost setcurrentchannel setcurrenttask setcurrentwaypoint
-syn keyword     sqfCommand      setcustomaimcoef setcustommissiondata setcustomsoundcontroller setcustomweightrtd
-syn keyword     sqfCommand      setdamage setdammage setdate setdebriefingtext setdefaultcamera setdestination
-syn keyword     sqfCommand      setdetailmapblendpars setdir setdirection setdrawicon setdriveonpath setdropinterval
-syn keyword     sqfCommand      setdynamicsimulationdistance setdynamicsimulationdistancecoef seteditormode
-syn keyword     sqfCommand      seteditorobjectscope seteffectcondition setenginerpmrtd setface setfaceanimation
-syn keyword     sqfCommand      setfatigue setfeaturetype setflaganimationphase setflagowner setflagside setflagtexture
-syn keyword     sqfCommand      setfog setforcegeneratorrtd setformation setformationtask setformdir setfriend
-syn keyword     sqfCommand      setfromeditor setfsmvariable setfuel setfuelcargo setgroupicon setgroupiconparams
-syn keyword     sqfCommand      setgroupiconsselectable setgroupiconsvisible setgroupid setgroupidglobal setgroupowner
-syn keyword     sqfCommand      setgusts sethidebehind sethit sethitindex sethitpointdamage sethorizonparallaxcoef
-syn keyword     sqfCommand      sethudmovementlevels setidentity setimportance setinfopanel setleader setlightambient
-syn keyword     sqfCommand      setlightattenuation setlightbrightness setlightcolor setlightdaylight
-syn keyword     sqfCommand      setlightflaremaxdistance setlightflaresize setlightintensity setlightnings
-syn keyword     sqfCommand      setlightuseflare setlocalwindparams setmagazineturretammo setmarkeralpha
-syn keyword     sqfCommand      setmarkeralphalocal setmarkerbrush setmarkerbrushlocal setmarkercolor
-syn keyword     sqfCommand      setmarkercolorlocal setmarkerdir setmarkerdirlocal setmarkerpos setmarkerposlocal
-syn keyword     sqfCommand      setmarkershape setmarkershapelocal setmarkersize setmarkersizelocal setmarkertext
-syn keyword     sqfCommand      setmarkertextlocal setmarkertype setmarkertypelocal setmass setmimic setmissiletarget
-syn keyword     sqfCommand      setmissiletargetpos setmouseposition setmusiceffect setmusiceventhandler setname
-syn keyword     sqfCommand      setnamesound setobjectarguments setobjectmaterial setobjectmaterialglobal setobjectproxy
-syn keyword     sqfCommand      setobjecttexture setobjecttextureglobal setobjectviewdistance setovercast setowner
-syn keyword     sqfCommand      setoxygenremaining setparticlecircle setparticleclass setparticlefire setparticleparams
-syn keyword     sqfCommand      setparticlerandom setpilotcameradirection setpilotcamerarotation setpilotcameratarget
-syn keyword     sqfCommand      setpilotlight setpipeffect setpitch setplatenumber setplayable setplayerrespawntime
-syn keyword     sqfCommand      setpos setposasl setposasl2 setposaslw setposatl setposition setposworld setpylonloadout
-syn keyword     sqfCommand      setpylonspriority setradiomsg setrain setrainbow setrandomlip setrank setrectangular
-syn keyword     sqfCommand      setrepaircargo setrotorbrakertd setshadowdistance setshotparents setside
-syn keyword     sqfCommand      setsimpletaskalwaysvisible setsimpletaskcustomdata setsimpletaskdescription
-syn keyword     sqfCommand      setsimpletaskdestination setsimpletasktarget setsimpletasktype setsimulweatherlayers
-syn keyword     sqfCommand      setsize setskill setslingload setsoundeffect setspeaker setspeech setspeedmode
-syn keyword     sqfCommand      setstamina setstaminascheme setstatvalue setsuppression setsystemofunits settargetage
-syn keyword     sqfCommand      settaskmarkeroffset settaskresult settaskstate setterraingrid settext settimemultiplier
-syn keyword     sqfCommand      settitleeffect settrafficdensity settrafficdistance settrafficgap settrafficspeed
-syn keyword     sqfCommand      settriggeractivation settriggerarea settriggerstatements settriggertext
-syn keyword     sqfCommand      settriggertimeout settriggertype settype setunconscious setunitability setunitloadout
-syn keyword     sqfCommand      setunitpos setunitposweak setunitrank setunitrecoilcoefficient setunittrait
-syn keyword     sqfCommand      setunloadincombat setuseractiontext setusermfdtext setusermfdvalue setvariable
-syn keyword     sqfCommand      setvectordir setvectordirandup setvectorup setvehicleammo setvehicleammodef
-syn keyword     sqfCommand      setvehiclearmor setvehiclecargo setvehicleid setvehiclelock setvehicleposition
-syn keyword     sqfCommand      setvehicleradar setvehiclereceiveremotetargets setvehiclereportownposition
-syn keyword     sqfCommand      setvehiclereportremotetargets setvehicletipars setvehiclevarname setvelocity
-syn keyword     sqfCommand      setvelocitymodelspace setvelocitytransformation setviewdistance
-syn keyword     sqfCommand      setvisibleiftreecollapsed setwantedrpmrtd setwaves setwaypointbehaviour
-syn keyword     sqfCommand      setwaypointcombatmode setwaypointcompletionradius setwaypointdescription
-syn keyword     sqfCommand      setwaypointforcebehaviour setwaypointformation setwaypointhouseposition
-syn keyword     sqfCommand      setwaypointloiterradius setwaypointloitertype setwaypointname setwaypointposition
-syn keyword     sqfCommand      setwaypointscript setwaypointspeed setwaypointstatements setwaypointtimeout
-syn keyword     sqfCommand      setwaypointtype setwaypointvisible setweaponreloadingtime setwind setwinddir
-syn keyword     sqfCommand      setwindforce setwindstr setwingforcescalertd setwppos show3dicons showchat
-syn keyword     sqfCommand      showcinemaborder showcommandingmenu showcompass showcuratorcompass showgps showhud
-syn keyword     sqfCommand      showlegend showmap shownartillerycomputer shownchat showncompass showncuratorcompass
-syn keyword     sqfCommand      showneweditorobject showngps shownhud shownmap shownpad shownradio shownscoretable
-syn keyword     sqfCommand      shownuavfeed shownwarrant shownwatch showpad showradio showscoretable showsubtitles
-syn keyword     sqfCommand      showuavfeed showwarrant showwatch showwaypoint showwaypoints side sideambientlife
-syn keyword     sqfCommand      sidechat sideempty sideenemy sidefriendly sidelogic sideradio simpletasks
-syn keyword     sqfCommand      simulationenabled simulclouddensity simulcloudocclusion simulinclouds simulweathersync
-syn keyword     sqfCommand      sin size sizeof skill skillfinal skiptime sliderposition sliderrange slidersetposition
-syn keyword     sqfCommand      slidersetrange slidersetspeed sliderspeed slingloadassistantshown soldiermagazines
-syn keyword     sqfCommand      someammo sort soundvolume speaker speed speedmode splitstring sqrt squadparams stance
-syn keyword     sqfCommand      startloadingscreen step stop stopenginertd stopped str sunormoon supportinfo suppressfor
-syn keyword     sqfCommand      surfaceiswater surfacenormal surfacetype swimindepth switchableunits switchaction
-syn keyword     sqfCommand      switchcamera switchgesture switchlight switchmove synchronizedobjects
-syn keyword     sqfCommand      synchronizedtriggers synchronizedwaypoints synchronizeobjectsadd
-syn keyword     sqfCommand      synchronizeobjectsremove synchronizetrigger synchronizewaypoint systemchat systemofunits
-syn keyword     sqfCommand      tan targetknowledge targets targetsaggregate targetsquery taskalwaysvisible taskchildren
-syn keyword     sqfCommand      taskcompleted taskcustomdata taskdescription taskdestination taskhint taskmarkeroffset
-syn keyword     sqfCommand      taskparent taskresult taskstate tasktype teammember teamname teams teamswitch
-syn keyword     sqfCommand      teamswitchenabled teamtype terrainintersect terrainintersectasl terrainintersectatasl
-syn keyword     sqfCommand      text textlog textlogformat tg time timemultiplier titlecut titlefadeout titleobj
-syn keyword     sqfCommand      titlersc titletext toarray tofixed tolower tostring toupper triggeractivated
-syn keyword     sqfCommand      triggeractivation triggerammo triggerarea triggerattachedvehicle triggerattachobject
-syn keyword     sqfCommand      triggerattachvehicle triggerdynamicsimulation triggerstatements triggertext
-syn keyword     sqfCommand      triggertimeout triggertimeoutcurrent triggertype turretlocal turretowner turretunit
-syn keyword     sqfCommand      tvadd tvclear tvcollapse tvcollapseall tvcount tvcursel tvdata tvdelete tvexpand
-syn keyword     sqfCommand      tvexpandall tvpicture tvpictureright tvsetcolor tvsetcursel tvsetdata tvsetpicture
-syn keyword     sqfCommand      tvsetpicturecolor tvsetpicturecolordisabled tvsetpicturecolorselected tvsetpictureright
-syn keyword     sqfCommand      tvsetpicturerightcolor tvsetpicturerightcolordisabled tvsetpicturerightcolorselected
-syn keyword     sqfCommand      tvsetselectcolor tvsettext tvsettooltip tvsetvalue tvsort tvsortbyvalue tvtext tvtooltip
-syn keyword     sqfCommand      tvvalue type typename typeof uavcontrol uinamespace uisleep unassigncurator unassignitem
-syn keyword     sqfCommand      unassignteam unassignvehicle underwater uniform uniformcontainer uniformitems
-syn keyword     sqfCommand      uniformmagazines unitaddons unitaimposition unitaimpositionvisual unitbackpack unitisuav
-syn keyword     sqfCommand      unitpos unitready unitrecoilcoefficient units unitsbelowheight unlinkitem
-syn keyword     sqfCommand      unlockachievement unregistertask updatedrawicon updatemenuitem updateobjecttree
-syn keyword     sqfCommand      useaiopermapobstructiontest useaisteeringcomponent useaudiotimeformoves
-syn keyword     sqfCommand      userinputdisabled vectoradd vectorcos vectorcrossproduct vectordiff vectordir
-syn keyword     sqfCommand      vectordirvisual vectordistance vectordistancesqr vectordotproduct vectorfromto
-syn keyword     sqfCommand      vectorlinearconversion vectormagnitude vectormagnitudesqr vectormodeltoworld
-syn keyword     sqfCommand      vectormodeltoworldvisual vectormultiply vectornormalized vectorup vectorupvisual
-syn keyword     sqfCommand      vectorworldtomodel vectorworldtomodelvisual vehicle vehiclecargoenabled vehiclechat
-syn keyword     sqfCommand      vehicleradio vehiclereceiveremotetargets vehiclereportownposition
-syn keyword     sqfCommand      vehiclereportremotetargets vehicles vehiclevarname velocity velocitymodelspace
-syn keyword     sqfCommand      verifysignature vest vestcontainer vestitems vestmagazines viewdistance visiblecompass
-syn keyword     sqfCommand      visiblegps visiblemap visibleposition visiblepositionasl visiblescoretable visiblewatch
-syn keyword     sqfCommand      waves waypointattachedobject waypointattachedvehicle waypointattachobject
-syn keyword     sqfCommand      waypointattachvehicle waypointbehaviour waypointcombatmode waypointcompletionradius
-syn keyword     sqfCommand      waypointdescription waypointforcebehaviour waypointformation waypointhouseposition
-syn keyword     sqfCommand      waypointloiterradius waypointloitertype waypointname waypointposition waypoints
-syn keyword     sqfCommand      waypointscript waypointsenableduav waypointshow waypointspeed waypointstatements
-syn keyword     sqfCommand      waypointtimeout waypointtimeoutcurrent waypointtype waypointvisible weaponaccessories
-syn keyword     sqfCommand      weaponaccessoriescargo weaponcargo weapondirection weaponinertia weaponlowered weapons
-syn keyword     sqfCommand      weaponsitems weaponsitemscargo weaponstate weaponsturret weightrtd wfsidetext wind
-syn keyword     sqfCommand      winddir windrtd windstr wingsforcesrtd worldname worldsize worldtomodel
-syn keyword     sqfCommand      worldtomodelvisual worldtoscreen
+" START GEN
+syn keyword sqfCommand      abs acctime acos action actionids actionkeys actionkeysimages actionkeysnames
+syn keyword sqfCommand      actionkeysnamesarray actionname actionparams activateaddons activatedaddons activatekey
+syn keyword sqfCommand      add3denconnection add3deneventhandler add3denlayer addaction addbackpack addbackpackcargo
+syn keyword sqfCommand      addbackpackcargoglobal addbackpackglobal addcamshake addcuratoraddons addcuratorcameraarea
+syn keyword sqfCommand      addcuratoreditableobjects addcuratoreditingarea addcuratorpoints addeditorobject
+syn keyword sqfCommand      addeventhandler addforce addforcegeneratorrtd addgoggles addgroupicon addhandgunitem
+syn keyword sqfCommand      addheadgear additem additemcargo additemcargoglobal additempool additemtobackpack
+syn keyword sqfCommand      additemtouniform additemtovest addlivestats addmagazine addmagazineammocargo
+syn keyword sqfCommand      addmagazinecargo addmagazinecargoglobal addmagazineglobal addmagazinepool addmagazines
+syn keyword sqfCommand      addmagazineturret addmenu addmenuitem addmissioneventhandler addmpeventhandler
+syn keyword sqfCommand      addmusiceventhandler addownedmine addplayerscores addprimaryweaponitem
+syn keyword sqfCommand      addpublicvariableeventhandler addrating addresources addscore addscoreside
+syn keyword sqfCommand      addsecondaryweaponitem addswitchableunit addteammember addtoremainscollector addtorque
+syn keyword sqfCommand      adduniform addvehicle addvest addwaypoint addweapon addweaponcargo addweaponcargoglobal
+syn keyword sqfCommand      addweaponglobal addweaponitem addweaponpool addweaponturret addweaponwithattachmentscargo
+syn keyword sqfCommand      addweaponwithattachmentscargoglobal admin agent agents agltoasl aimedattarget aimpos
+syn keyword sqfCommand      airdensitycurvertd airdensityrtd airplanethrottle airportside aisfinishheal alive
+syn keyword sqfCommand      all3denentities allairports allcontrols allcurators allcutlayers alldead alldeadmen
+syn keyword sqfCommand      alldisplays allgroups allmapmarkers allmines allmissionobjects allow3dmode
+syn keyword sqfCommand      allowcrewinimmobile allowcuratorlogicignoreareas allowdamage allowdammage
+syn keyword sqfCommand      allowfileoperations allowfleeing allowgetin allowsprint allplayers allsimpleobjects allsites
+syn keyword sqfCommand      allturrets allunits allunitsuav allvariables ammo ammoonpylon and animate animatebay
+syn keyword sqfCommand      animatedoor animatepylon animatesource animationnames animationphase animationsourcephase
+syn keyword sqfCommand      animationstate append apply armorypoints arrayintersect asin asltoagl asltoatl assert
+syn keyword sqfCommand      assignascargo assignascargoindex assignascommander assignasdriver assignasgunner
+syn keyword sqfCommand      assignasturret assigncurator assignedcargo assignedcommander assigneddriver assignedgunner
+syn keyword sqfCommand      assigneditems assignedtarget assignedteam assignedvehicle assignedvehiclerole assignitem
+syn keyword sqfCommand      assignteam assigntoairport atan atan2 atg atltoasl attachedobject attachedobjects attachedto
+syn keyword sqfCommand      attachobject attachto attackenabled backpack backpackcargo backpackcontainer backpackitems
+syn keyword sqfCommand      backpackmagazines backpackspacefor behaviour benchmark bezierinterpolation binocular blufor
+syn keyword sqfCommand      boundingbox boundingboxreal boundingcenter breakout breakto briefingname buildingexit
+syn keyword sqfCommand      buildingpos buldozer_enableroaddiag buldozer_isenabledroaddiag buldozer_loadnewroads
+syn keyword sqfCommand      buldozer_reloadopermap buttonaction buttonsetaction cadetmode calculatepath
+syn keyword sqfCommand      calculateplayervisibilitybyfriendly camcommand camcommit camcommitprepared camcommitted
+syn keyword sqfCommand      camconstuctionsetparams camcreate camdestroy cameraeffect cameraeffectenablehud
+syn keyword sqfCommand      camerainterest cameraon cameraview campaignconfigfile campreload campreloaded campreparebank
+syn keyword sqfCommand      campreparedir campreparedive campreparefocus campreparefov campreparefovrange campreparepos
+syn keyword sqfCommand      campreparerelpos campreparetarget camsetbank camsetdir camsetdive camsetfocus camsetfov
+syn keyword sqfCommand      camsetfovrange camsetpos camsetrelpos camsettarget camtarget camusenvg canadd
+syn keyword sqfCommand      canadditemtobackpack canadditemtouniform canadditemtovest cancelsimpletaskdestination
+syn keyword sqfCommand      canfire canmove canslingload canstand cansuspend cantriggerdynamicsimulation
+syn keyword sqfCommand      canunloadincombat canvehiclecargo captive captivenum cbchecked cbsetchecked ceil
+syn keyword sqfCommand      channelenabled cheatsenabled checkaifeature checkvisibility classname clear3denattribute
+syn keyword sqfCommand      clear3deninventory clearallitemsfrombackpack clearbackpackcargo clearbackpackcargoglobal
+syn keyword sqfCommand      clearforcesrtd cleargroupicons clearitemcargo clearitemcargoglobal clearitempool
+syn keyword sqfCommand      clearmagazinecargo clearmagazinecargoglobal clearmagazinepool clearoverlay clearradio
+syn keyword sqfCommand      clearweaponcargo clearweaponcargoglobal clearweaponpool clientowner closedialog closedisplay
+syn keyword sqfCommand      closeoverlay collapseobjecttree collect3denhistory collectivertd combatmode
+syn keyword sqfCommand      commandartilleryfire commandchat commander commandfire commandfollow commandgetout
+syn keyword sqfCommand      commandingmenu commandmove commandradio commandstop commandsuppressivefire commandtarget
+syn keyword sqfCommand      commandwatch comment commitoverlay completedfsm composetext configclasses configfile
+syn keyword sqfCommand      confighierarchy configname confignull configproperties configsourceaddonlist configsourcemod
+syn keyword sqfCommand      configsourcemodlist confirmsensortarget connectterminaltouav controlsgroupctrl
+syn keyword sqfCommand      copyfromclipboard copytoclipboard copywaypoints cos countenemy countfriendly countside
+syn keyword sqfCommand      counttype countunknown create3dencomposition create3denentity createagent createcenter
+syn keyword sqfCommand      createdialog creatediarylink creatediaryrecord creatediarysubject createdisplay
+syn keyword sqfCommand      creategeardialog creategroup createguardedpoint createlocation createmarker
+syn keyword sqfCommand      createmarkerlocal createmenu createmine createmissiondisplay creatempcampaigndisplay
+syn keyword sqfCommand      createsimpleobject createsimpletask createsite createsoundsource createtask createteam
+syn keyword sqfCommand      createtrigger createunit createvehicle createvehiclecrew createvehiclelocal crew ctaddheader
+syn keyword sqfCommand      ctaddrow ctclear ctcursel ctdata ctfindheaderrows ctfindrowheader ctheadercontrols
+syn keyword sqfCommand      ctheadercount ctremoveheaders ctremoverows ctrlactivate ctrladdeventhandler ctrlangle
+syn keyword sqfCommand      ctrlanimatemodel ctrlanimationphasemodel ctrlautoscrolldelay ctrlautoscrollrewind
+syn keyword sqfCommand      ctrlautoscrollspeed ctrlchecked ctrlclassname ctrlcommit ctrlcommitted ctrlcreate ctrldelete
+syn keyword sqfCommand      ctrlenable ctrlenabled ctrlfade ctrlhtmlloaded ctrlidc ctrlidd ctrlmapanimadd
+syn keyword sqfCommand      ctrlmapanimclear ctrlmapanimcommit ctrlmapanimdone ctrlmapcursor ctrlmapmouseover
+syn keyword sqfCommand      ctrlmapscale ctrlmapscreentoworld ctrlmapworldtoscreen ctrlmodel ctrlmodeldirandup
+syn keyword sqfCommand      ctrlmodelscale ctrlparent ctrlparentcontrolsgroup ctrlposition ctrlremovealleventhandlers
+syn keyword sqfCommand      ctrlremoveeventhandler ctrlscale ctrlsetactivecolor ctrlsetangle ctrlsetautoscrolldelay
+syn keyword sqfCommand      ctrlsetautoscrollrewind ctrlsetautoscrollspeed ctrlsetbackgroundcolor ctrlsetchecked
+syn keyword sqfCommand      ctrlsetdisabledcolor ctrlseteventhandler ctrlsetfade ctrlsetfocus ctrlsetfont ctrlsetfonth1
+syn keyword sqfCommand      ctrlsetfonth1b ctrlsetfonth2 ctrlsetfonth2b ctrlsetfonth3 ctrlsetfonth3b ctrlsetfonth4
+syn keyword sqfCommand      ctrlsetfonth4b ctrlsetfonth5 ctrlsetfonth5b ctrlsetfonth6 ctrlsetfonth6b ctrlsetfontheight
+syn keyword sqfCommand      ctrlsetfontheighth1 ctrlsetfontheighth2 ctrlsetfontheighth3 ctrlsetfontheighth4
+syn keyword sqfCommand      ctrlsetfontheighth5 ctrlsetfontheighth6 ctrlsetfontheightsecondary ctrlsetfontp
+syn keyword sqfCommand      ctrlsetfontpb ctrlsetfontsecondary ctrlsetforegroundcolor ctrlsetmodel ctrlsetmodeldirandup
+syn keyword sqfCommand      ctrlsetmodelscale ctrlsetpixelprecision ctrlsetposition ctrlsetpositionh ctrlsetpositionw
+syn keyword sqfCommand      ctrlsetpositionx ctrlsetpositiony ctrlsetscale ctrlsetstructuredtext ctrlsettext
+syn keyword sqfCommand      ctrlsettextcolor ctrlsettextcolorsecondary ctrlsettextsecondary ctrlsettooltip
+syn keyword sqfCommand      ctrlsettooltipcolorbox ctrlsettooltipcolorshade ctrlsettooltipcolortext ctrlshow ctrlshown
+syn keyword sqfCommand      ctrltext ctrltextheight ctrltextsecondary ctrltextwidth ctrltype ctrlvisible ctrowcontrols
+syn keyword sqfCommand      ctrowcount ctsetcursel ctsetdata ctsetheadertemplate ctsetrowtemplate ctsetvalue ctvalue
+syn keyword sqfCommand      curatoraddons curatorcamera curatorcameraarea curatorcameraareaceiling curatorcoef
+syn keyword sqfCommand      curatoreditableobjects curatoreditingarea curatoreditingareatype curatormouseover
+syn keyword sqfCommand      curatorpoints curatorregisteredobjects curatorselected curatorwaypointcost
+syn keyword sqfCommand      current3denoperation currentchannel currentcommand currentmagazine currentmagazinedetail
+syn keyword sqfCommand      currentmagazinedetailturret currentmagazineturret currentmuzzle currentnamespace currenttask
+syn keyword sqfCommand      currenttasks currentthrowable currentvisionmode currentwaypoint currentweapon
+syn keyword sqfCommand      currentweaponmode currentweaponturret currentzeroing cursorobject cursortarget customchat
+syn keyword sqfCommand      customradio customwaypointposition cutfadeout cutobj cutrsc cuttext damage date datetonumber
+syn keyword sqfCommand      daytime deactivatekey debriefingtext debugfsm debuglog decaygraphvalues deg
+syn keyword sqfCommand      delete3denentities deleteat deletecenter deletecollection deleteeditorobject deletegroup
+syn keyword sqfCommand      deletegroupwhenempty deleteidentity deletelocation deletemarker deletemarkerlocal
+syn keyword sqfCommand      deleterange deleteresources deletesite deletestatus deleteteam deletevehicle
+syn keyword sqfCommand      deletevehiclecrew deletewaypoint detach detectedmines diag_activemissionfsms
+syn keyword sqfCommand      diag_activescripts diag_activesqfscripts diag_activesqsscripts diag_codeperformance
+syn keyword sqfCommand      diag_dynamicsimulationend diag_fps diag_fpsmin diag_frameno diag_lightnewload diag_log
+syn keyword sqfCommand      diag_setlightnew diag_ticktime dialog diarysubjectexists didjip didjipowner difficulty
+syn keyword sqfCommand      difficultyenabled difficultyenabledrtd difficultyoption direction directsay disableai
+syn keyword sqfCommand      disablecollisionwith disableconversation disabledebriefingstats disablemapindicators
+syn keyword sqfCommand      disablenvgequipment disableremotesensors disableserialization disabletiequipment
+syn keyword sqfCommand      disableuavconnectability disableuserinput displayaddeventhandler displayctrl displayparent
+syn keyword sqfCommand      displayremovealleventhandlers displayremoveeventhandler displayseteventhandler dissolveteam
+syn keyword sqfCommand      distance distance2d distancesqr distributionregion do3denaction doartilleryfire dofire
+syn keyword sqfCommand      dofollow dogetout domove doorphase dostop dosuppressivefire dotarget dowatch drawarrow
+syn keyword sqfCommand      drawellipse drawicon drawicon3d drawline drawline3d drawlink drawlocation drawpolygon
+syn keyword sqfCommand      drawrectangle drawtriangle driver drop dynamicsimulationdistance
+syn keyword sqfCommand      dynamicsimulationdistancecoef dynamicsimulationenabled dynamicsimulationsystemenabled echo
+syn keyword sqfCommand      edit3denmissionattributes editobject editorseteventhandler effectivecommander emptypositions
+syn keyword sqfCommand      enableai enableaifeature enableaimprecision enableattack enableaudiofeature
+syn keyword sqfCommand      enableautostartuprtd enableautotrimrtd enablecamshake enablecaustics enablechannel
+syn keyword sqfCommand      enablecollisionwith enablecopilot enabledebriefingstats enablediaglegend
+syn keyword sqfCommand      enabledynamicsimulation enabledynamicsimulationsystem enableenddialog enableengineartillery
+syn keyword sqfCommand      enableenvironment enablefatigue enablegunlights enableinfopanelcomponent enableirlasers
+syn keyword sqfCommand      enablemimics enablepersonturret enableradio enablereload enableropeattach
+syn keyword sqfCommand      enablesatnormalondetail enablesaving enablesentences enablesimulation enablesimulationglobal
+syn keyword sqfCommand      enablestamina enablestressdamage enableteamswitch enabletraffic enableuavconnectability
+syn keyword sqfCommand      enableuavwaypoints enablevehiclecargo enablevehiclesensor enableweapondisassembly endl
+syn keyword sqfCommand      endloadingscreen endmission engineon enginesisonrtd enginespowerrtd enginesrpmrtd
+syn keyword sqfCommand      enginestorquertd entities environmentenabled estimatedendservertime estimatedtimeleft
+syn keyword sqfCommand      evalobjectargument everybackpack everycontainer exec execeditorscript exit exp
+syn keyword sqfCommand      expecteddestination exportjipmessages eyedirection eyepos face faction fademusic faderadio
+syn keyword sqfCommand      fadesound fadespeech failmission fillweaponsfrompool find findcover finddisplay
+syn keyword sqfCommand      findeditorobject findemptyposition findemptypositionready findif findnearestenemy
+syn keyword sqfCommand      finishmissioninit finite fire fireattarget firstbackpack flag flaganimationphase flagowner
+syn keyword sqfCommand      flagside flagtexture fleeing floor flyinheight flyinheightasl fog fogforecast fogparams
+syn keyword sqfCommand      forceadduniform forceatpositionrtd forcedmap forceend forceflagtexture forcefollowroad
+syn keyword sqfCommand      forcegeneratorrtd forcemap forcerespawn forcespeed forcewalk forceweaponfire
+syn keyword sqfCommand      forceweatherchange foreachmember foreachmemberagent foreachmemberteam forgettarget format
+syn keyword sqfCommand      formation formationdirection formationleader formationmembers formationposition
+syn keyword sqfCommand      formationtask formattext formleader freelook fromeditor fuel fullcrew gearidcammocount
+syn keyword sqfCommand      gearslotammocount gearslotdata get3denactionstate get3denattribute get3dencamera
+syn keyword sqfCommand      get3denconnections get3denentity get3denentityid get3dengrid get3deniconsvisible
+syn keyword sqfCommand      get3denlayerentities get3denlinesvisible get3denmissionattribute get3denmouseover
+syn keyword sqfCommand      get3denselected getaimingcoef getallenvsoundcontrollers getallhitpointsdamage
+syn keyword sqfCommand      getallownedmines getallsoundcontrollers getammocargo getanimaimprecision getanimspeedcoef
+syn keyword sqfCommand      getarray getartilleryammo getartillerycomputersettings getartilleryeta
+syn keyword sqfCommand      getassignedcuratorlogic getassignedcuratorunit getaudiooptionvolumes getbackpackcargo
+syn keyword sqfCommand      getbleedingremaining getburningvalue getcalculateplayervisibilitybyfriendly
+syn keyword sqfCommand      getcameraviewdirection getcargoindex getcenterofmass getclientstate getclientstatenumber
+syn keyword sqfCommand      getcompatiblepylonmagazines getconnecteduav getcontainermaxload getcursorobjectparams
+syn keyword sqfCommand      getcustomaimcoef getcustomsoundcontroller getcustomsoundcontrollercount getdammage
+syn keyword sqfCommand      getdescription getdir getdirvisual getdlcassetsusage getdlcassetsusagebyname getdlcs
+syn keyword sqfCommand      getdlcusagetime geteditorcamera geteditormode geteditorobjectscope getelevationoffset
+syn keyword sqfCommand      getenginetargetrpmrtd getenvsoundcontroller getfatigue getfieldmanualstartpage
+syn keyword sqfCommand      getforcedflagtexture getfriend getfsmvariable getfuelcargo getgraphvalues getgroupicon
+syn keyword sqfCommand      getgroupiconparams getgroupicons gethidefrom gethit gethitindex gethitpointdamage
+syn keyword sqfCommand      getitemcargo getmagazinecargo getmarkercolor getmarkerpos getmarkersize getmarkertype
+syn keyword sqfCommand      getmass getmissionconfig getmissionconfigvalue getmissiondlcs getmissionlayerentities
+syn keyword sqfCommand      getmissionlayers getmodelinfo getmouseposition getmusicplayedtime getnumber
+syn keyword sqfCommand      getobjectargument getobjectchildren getobjectdlc getobjectmaterials getobjectproxy
+syn keyword sqfCommand      getobjecttextures getobjecttype getobjectviewdistance getoxygenremaining getpersonuseddlcs
+syn keyword sqfCommand      getpilotcameradirection getpilotcameraposition getpilotcamerarotation getpilotcameratarget
+syn keyword sqfCommand      getplatenumber getplayerchannel getplayerscores getplayeruid getpos getposasl
+syn keyword sqfCommand      getposaslvisual getposaslw getposatl getposatlvisual getposvisual getposworld
+syn keyword sqfCommand      getpylonmagazines getreldir getrelpos getremotesensorsdisabled getrepaircargo getresolution
+syn keyword sqfCommand      getrotorbrakertd getshadowdistance getshotparents getslingload getsoundcontroller
+syn keyword sqfCommand      getsoundcontrollerresult getspeed getstamina getstatvalue getsubtitleoptions getsuppression
+syn keyword sqfCommand      getterraingrid getterrainheightasl gettext gettotaldlcusagetime gettrimoffsetrtd
+syn keyword sqfCommand      getunitloadout getunittrait getusermfdtext getusermfdvalue getvariable getvehiclecargo
+syn keyword sqfCommand      getweaponcargo getweaponsway getwingsorientationrtd getwingspositionrtd getwppos glanceat
+syn keyword sqfCommand      globalchat globalradio goggles goto group groupchat groupfromnetid groupiconselectable
+syn keyword sqfCommand      groupiconsvisible groupid groupowner groupradio groupselectedunits groupselectunit gunner
+syn keyword sqfCommand      gusts halt handgunitems handgunmagazine handgunweapon handshit hasinterface haspilotcamera
+syn keyword sqfCommand      hasweapon hcallgroups hcgroupparams hcleader hcremoveallgroups hcremovegroup hcselected
+syn keyword sqfCommand      hcselectgroup hcsetgroup hcshowbar hcshownbar headgear hidebody hideobject hideobjectglobal
+syn keyword sqfCommand      hideselection hint hintc hintcadet hintsilent hmd hostmission htmlload hudmovementlevels
+syn keyword sqfCommand      humidity image importallgroups importance in inarea inareaarray incapacitatedstate inflame
+syn keyword sqfCommand      inflamed infopanel infopanelcomponentenabled infopanelcomponents infopanels
+syn keyword sqfCommand      ingameuiseteventhandler inheritsfrom initambientlife inpolygon inputaction
+syn keyword sqfCommand      inrangeofartillery inserteditorobject intersect is3den is3denmultiplayer isabletobreathe
+syn keyword sqfCommand      isagent isaimprecisionenabled isarray isautohoveron isautonomous isautostartupenabledrtd
+syn keyword sqfCommand      isautotest isautotrimonrtd isbleeding isburning isclass iscollisionlighton iscopilotenabled
+syn keyword sqfCommand      isdamageallowed isdedicated isdlcavailable isengineon isequalto isequaltype isequaltypeall
+syn keyword sqfCommand      isequaltypeany isequaltypearray isequaltypeparams isfilepatchingenabled isflashlighton
+syn keyword sqfCommand      isflatempty isforcedwalk isformationleader isgroupdeletedwhenempty ishidden
+syn keyword sqfCommand      isinremainscollector isinstructorfigureenabled isirlaseron iskeyactive iskindof islaseron
+syn keyword sqfCommand      islighton islocalized ismanualfire ismarkedforcollection ismultiplayer ismultiplayersolo
+syn keyword sqfCommand      isnil isnull isnumber isobjecthidden isobjectrtd isonroad ispipenabled isplayer isrealtime
+syn keyword sqfCommand      isremoteexecuted isremoteexecutedjip issensortargetconfirmed isserver isshowing3dicons
+syn keyword sqfCommand      issimpleobject issprintallowed isstaminaenabled issteammission isstreamfriendlyuienabled
+syn keyword sqfCommand      isstressdamageenabled istext istouchingground isturnedout istuthintsenabled isuavconnectable
+syn keyword sqfCommand      isuavconnected isuicontext isuniformallowed isvehiclecargo isvehicleradaron
+syn keyword sqfCommand      isvehiclesensorenabled iswalking isweapondeployed isweaponrested itemcargo items
+syn keyword sqfCommand      itemswithmagazines join joinas joinassilent joinsilent joinstring kbadddatabase
+syn keyword sqfCommand      kbadddatabasetargets kbaddtopic kbhastopic kbreact kbremovetopic kbtell kbwassaid keyimage
+syn keyword sqfCommand      keyname knowsabout land landat landresult language lasertarget lbadd lbclear lbcolor
+syn keyword sqfCommand      lbcolorright lbcursel lbdata lbdelete lbisselected lbpicture lbpictureright lbselection
+syn keyword sqfCommand      lbsetcolor lbsetcolorright lbsetcursel lbsetdata lbsetpicture lbsetpicturecolor
+syn keyword sqfCommand      lbsetpicturecolordisabled lbsetpicturecolorselected lbsetpictureright lbsetpicturerightcolor
+syn keyword sqfCommand      lbsetpicturerightcolordisabled lbsetpicturerightcolorselected lbsetselectcolor
+syn keyword sqfCommand      lbsetselectcolorright lbsetselected lbsettext lbsettextright lbsettooltip lbsetvalue lbsize
+syn keyword sqfCommand      lbsort lbsortbyvalue lbtext lbtextright lbvalue leader leaderboarddeinit leaderboardgetrows
+syn keyword sqfCommand      leaderboardinit leaderboardrequestrowsfriends leaderboardrequestrowsglobal
+syn keyword sqfCommand      leaderboardrequestrowsglobalarounduser leaderboardsrequestuploadscore
+syn keyword sqfCommand      leaderboardsrequestuploadscorekeepbest leaderboardstate leavevehicle librarycredits
+syn keyword sqfCommand      librarydisclaimers lifestate lightattachobject lightdetachobject lightison lightnings
+syn keyword sqfCommand      limitspeed linearconversion linebreak lineintersects lineintersectsobjs
+syn keyword sqfCommand      lineintersectssurfaces lineintersectswith linkitem list listobjects listremotetargets
+syn keyword sqfCommand      listvehiclesensors ln lnbaddarray lnbaddcolumn lnbaddrow lnbclear lnbcolor lnbcolorright
+syn keyword sqfCommand      lnbcurselrow lnbdata lnbdeletecolumn lnbdeleterow lnbgetcolumnsposition lnbpicture
+syn keyword sqfCommand      lnbpictureright lnbsetcolor lnbsetcolorright lnbsetcolumnspos lnbsetcurselrow lnbsetdata
+syn keyword sqfCommand      lnbsetpicture lnbsetpicturecolor lnbsetpicturecolorright lnbsetpicturecolorselected
+syn keyword sqfCommand      lnbsetpicturecolorselectedright lnbsetpictureright lnbsettext lnbsettextright lnbsettooltip
+syn keyword sqfCommand      lnbsetvalue lnbsize lnbsort lnbsortbyvalue lnbtext lnbtextright lnbvalue load loadabs
+syn keyword sqfCommand      loadbackpack loadfile loadgame loadidentity loadmagazine loadoverlay loadstatus loaduniform
+syn keyword sqfCommand      loadvest local localize locationposition lock lockcamerato lockcargo lockdriver locked
+syn keyword sqfCommand      lockedcargo lockeddriver lockedturret lockidentity lockturret lockwp log logentities
+syn keyword sqfCommand      lognetwork lognetworkterminate lookat lookatpos magazinecargo magazines magazinesallturrets
+syn keyword sqfCommand      magazinesammo magazinesammocargo magazinesammofull magazinesdetail magazinesdetailbackpack
+syn keyword sqfCommand      magazinesdetailuniform magazinesdetailvest magazinesturret magazineturretammo mapanimadd
+syn keyword sqfCommand      mapanimclear mapanimcommit mapanimdone mapcenteroncamera mapgridposition
+syn keyword sqfCommand      markasfinishedonsteam markeralpha markerbrush markercolor markerdir markerpos markershape
+syn keyword sqfCommand      markersize markertext markertype matrixmultiply matrixtranspose max members menuaction
+syn keyword sqfCommand      menuadd menuchecked menuclear menucollapse menudata menudelete menuenable menuenabled
+syn keyword sqfCommand      menuexpand menuhover menupicture menusetaction menusetcheck menusetdata menusetpicture
+syn keyword sqfCommand      menusetvalue menushortcut menushortcuttext menusize menusort menutext menuurl menuvalue min
+syn keyword sqfCommand      mineactive minedetectedby missiletarget missiletargetpos missionconfigfile missiondifficulty
+syn keyword sqfCommand      missionname missionnamespace missionstart missionversion mod modeltoworld modeltoworldvisual
+syn keyword sqfCommand      modeltoworldvisualworld modeltoworldworld modparams moonintensity moonphase morale move
+syn keyword sqfCommand      move3dencamera moveinany moveincargo moveincommander moveindriver moveingunner moveinturret
+syn keyword sqfCommand      moveobjecttoend moveout movetime moveto movetocompleted movetofailed musicvolume name
+syn keyword sqfCommand      namesound nearentities nearestbuilding nearestlocation nearestlocations
+syn keyword sqfCommand      nearestlocationwithdubbing nearestobject nearestobjects nearestterrainobjects nearobjects
+syn keyword sqfCommand      nearobjectsready nearroads nearsupplies neartargets needreload netid newoverlay
+syn keyword sqfCommand      nextmenuitemindex nextweatherchange nmenuitems not numberofenginesrtd numbertodate
+syn keyword sqfCommand      objectcurators objectfromnetid objectparent objstatus onbriefinggroup onbriefingnotes
+syn keyword sqfCommand      onbriefingplan onbriefingteamswitch oncommandmodechanged ondoubleclick oneachframe
+syn keyword sqfCommand      ongroupiconclick ongroupiconoverenter ongroupiconoverleave onhcgroupselectionchanged
+syn keyword sqfCommand      onmapsingleclick onplayerconnected onplayerdisconnected onpreloadfinished onpreloadstarted
+syn keyword sqfCommand      onshownewobject onteamswitch opencuratorinterface opendlcpage openmap opensteamapp
+syn keyword sqfCommand      openyoutubevideo opfor or ordergetin overcast overcastforecast owner param params
+syn keyword sqfCommand      parsenumber parsesimplearray parsetext parsingnamespace particlesquality pi pickweaponpool
+syn keyword sqfCommand      pitch pixelgrid pixelgridbase pixelgridnouiscale pixelh pixelw playableslotsnumber
+syn keyword sqfCommand      playableunits playaction playactionnow player playerrespawntime playerside playersnumber
+syn keyword sqfCommand      playgesture playmission playmove playmovenow playmusic playscriptedmission playsound
+syn keyword sqfCommand      playsound3d position positioncameratoworld posscreentoworld posworldtoscreen ppeffectadjust
+syn keyword sqfCommand      ppeffectcommit ppeffectcommitted ppeffectcreate ppeffectdestroy ppeffectenable
+syn keyword sqfCommand      ppeffectenabled ppeffectforceinnvg precision preloadcamera preloadobject preloadsound
+syn keyword sqfCommand      preloadtitleobj preloadtitlersc primaryweapon primaryweaponitems primaryweaponmagazine
+syn keyword sqfCommand      priority processdiarylink productversion profilename profilenamespace profilenamesteam
+syn keyword sqfCommand      progressloadingscreen progressposition progresssetposition publicvariable
+syn keyword sqfCommand      publicvariableclient publicvariableserver pushback pushbackunique putweaponpool
+syn keyword sqfCommand      queryitemspool querymagazinepool queryweaponpool rad radiochanneladd radiochannelcreate
+syn keyword sqfCommand      radiochannelremove radiochannelsetcallsign radiochannelsetlabel radiovolume rain rainbow
+syn keyword sqfCommand      random rank rankid rating rectangular registeredtasks registertask reload reloadenabled
+syn keyword sqfCommand      remotecontrol remoteexec remoteexeccall remoteexecutedowner remove3denconnection
+syn keyword sqfCommand      remove3deneventhandler remove3denlayer removeaction removeall3deneventhandlers
+syn keyword sqfCommand      removeallactions removeallassigneditems removeallcontainers removeallcuratoraddons
+syn keyword sqfCommand      removeallcuratorcameraareas removeallcuratoreditingareas removealleventhandlers
+syn keyword sqfCommand      removeallhandgunitems removeallitems removeallitemswithmagazines
+syn keyword sqfCommand      removeallmissioneventhandlers removeallmpeventhandlers removeallmusiceventhandlers
+syn keyword sqfCommand      removeallownedmines removeallprimaryweaponitems removeallweapons removebackpack
+syn keyword sqfCommand      removebackpackglobal removecuratoraddons removecuratorcameraarea
+syn keyword sqfCommand      removecuratoreditableobjects removecuratoreditingarea removedrawicon removedrawlinks
+syn keyword sqfCommand      removeeventhandler removefromremainscollector removegoggles removegroupicon
+syn keyword sqfCommand      removehandgunitem removeheadgear removeitem removeitemfrombackpack removeitemfromuniform
+syn keyword sqfCommand      removeitemfromvest removeitems removemagazine removemagazineglobal removemagazines
+syn keyword sqfCommand      removemagazinesturret removemagazineturret removemenuitem removemissioneventhandler
+syn keyword sqfCommand      removempeventhandler removemusiceventhandler removeownedmine removeprimaryweaponitem
+syn keyword sqfCommand      removesecondaryweaponitem removesimpletask removeswitchableunit removeteammember
+syn keyword sqfCommand      removeuniform removevest removeweapon removeweaponattachmentcargo removeweaponcargo
+syn keyword sqfCommand      removeweaponglobal removeweaponturret reportremotetarget requiredversion resetcamshake
+syn keyword sqfCommand      resetsubgroupdirection resize resources respawnvehicle restarteditorcamera reveal revealmine
+syn keyword sqfCommand      reverse reversedmousey roadat roadsconnectedto roledescription ropeattachedobjects
+syn keyword sqfCommand      ropeattachedto ropeattachenabled ropeattachto ropecreate ropecut ropedestroy ropedetach
+syn keyword sqfCommand      ropeendposition ropelength ropes ropeunwind ropeunwound rotorsforcesrtd rotorsrpmrtd round
+syn keyword sqfCommand      runinitscript safezoneh safezonew safezonewabs safezonex safezonexabs safezoney
+syn keyword sqfCommand      save3deninventory savegame saveidentity savejoysticks saveoverlay saveprofilenamespace
+syn keyword sqfCommand      savestatus savevar savingenabled say say2d say3d scopename score scoreside screenshot
+syn keyword sqfCommand      screentoworld scriptname scudstate secondaryweapon secondaryweaponitems
+syn keyword sqfCommand      secondaryweaponmagazine select selectbestplaces selectdiarysubject selectededitorobjects
+syn keyword sqfCommand      selecteditorobject selectionnames selectionposition selectleader selectmax selectmin
+syn keyword sqfCommand      selectnoplayer selectplayer selectrandom selectrandomweighted selectweapon
+syn keyword sqfCommand      selectweaponturret sendaumessage sendsimplecommand sendtask sendtaskresult sendudpmessage
+syn keyword sqfCommand      servercommand servercommandavailable servercommandexecutable servername servertime set
+syn keyword sqfCommand      set3denattribute set3denattributes set3dengrid set3deniconsvisible set3denlayer
+syn keyword sqfCommand      set3denlinesvisible set3denlogictype set3denmissionattribute set3denmissionattributes
+syn keyword sqfCommand      set3denmodelsvisible set3denobjecttype set3denselected setacctime setactualcollectivertd
+syn keyword sqfCommand      setairplanethrottle setairportside setammo setammocargo setammoonpylon setanimspeedcoef
+syn keyword sqfCommand      setaperture setaperturenew setarmorypoints setattributes setautonomous setbehaviour
+syn keyword sqfCommand      setbehaviourstrong setbleedingremaining setbrakesrtd setcamerainterest setcamshakedefparams
+syn keyword sqfCommand      setcamshakeparams setcamuseti setcaptive setcenterofmass setcollisionlight setcombatmode
+syn keyword sqfCommand      setcompassoscillation setconvoyseparation setcuratorcameraareaceiling setcuratorcoef
+syn keyword sqfCommand      setcuratoreditingareatype setcuratorwaypointcost setcurrentchannel setcurrenttask
+syn keyword sqfCommand      setcurrentwaypoint setcustomaimcoef setcustommissiondata setcustomsoundcontroller
+syn keyword sqfCommand      setcustomweightrtd setdamage setdammage setdate setdebriefingtext setdefaultcamera
+syn keyword sqfCommand      setdestination setdetailmapblendpars setdir setdirection setdrawicon setdriveonpath
+syn keyword sqfCommand      setdropinterval setdynamicsimulationdistance setdynamicsimulationdistancecoef seteditormode
+syn keyword sqfCommand      seteditorobjectscope seteffectcondition setenginerpmrtd setface setfaceanimation setfatigue
+syn keyword sqfCommand      setfeaturetype setflaganimationphase setflagowner setflagside setflagtexture setfog
+syn keyword sqfCommand      setforcegeneratorrtd setformation setformationtask setformdir setfriend setfromeditor
+syn keyword sqfCommand      setfsmvariable setfuel setfuelcargo setgroupicon setgroupiconparams setgroupiconsselectable
+syn keyword sqfCommand      setgroupiconsvisible setgroupid setgroupidglobal setgroupowner setgusts sethidebehind sethit
+syn keyword sqfCommand      sethitindex sethitpointdamage sethorizonparallaxcoef sethudmovementlevels setidentity
+syn keyword sqfCommand      setimportance setinfopanel setleader setlightambient setlightattenuation setlightbrightness
+syn keyword sqfCommand      setlightcolor setlightdaylight setlightflaremaxdistance setlightflaresize setlightintensity
+syn keyword sqfCommand      setlightnings setlightuseflare setlocalwindparams setmagazineturretammo setmarkeralpha
+syn keyword sqfCommand      setmarkeralphalocal setmarkerbrush setmarkerbrushlocal setmarkercolor setmarkercolorlocal
+syn keyword sqfCommand      setmarkerdir setmarkerdirlocal setmarkerpos setmarkerposlocal setmarkershape
+syn keyword sqfCommand      setmarkershapelocal setmarkersize setmarkersizelocal setmarkertext setmarkertextlocal
+syn keyword sqfCommand      setmarkertype setmarkertypelocal setmass setmimic setmissiletarget setmissiletargetpos
+syn keyword sqfCommand      setmouseposition setmusiceffect setmusiceventhandler setname setnamesound setobjectarguments
+syn keyword sqfCommand      setobjectmaterial setobjectmaterialglobal setobjectproxy setobjecttexture
+syn keyword sqfCommand      setobjecttextureglobal setobjectviewdistance setovercast setowner setoxygenremaining
+syn keyword sqfCommand      setparticlecircle setparticleclass setparticlefire setparticleparams setparticlerandom
+syn keyword sqfCommand      setpilotcameradirection setpilotcamerarotation setpilotcameratarget setpilotlight
+syn keyword sqfCommand      setpipeffect setpitch setplatenumber setplayable setplayerrespawntime setpos setposasl
+syn keyword sqfCommand      setposasl2 setposaslw setposatl setposition setposworld setpylonloadout setpylonspriority
+syn keyword sqfCommand      setradiomsg setrain setrainbow setrandomlip setrank setrectangular setrepaircargo
+syn keyword sqfCommand      setrotorbrakertd setshadowdistance setshotparents setside setsimpletaskalwaysvisible
+syn keyword sqfCommand      setsimpletaskcustomdata setsimpletaskdescription setsimpletaskdestination
+syn keyword sqfCommand      setsimpletasktarget setsimpletasktype setsimulweatherlayers setsize setskill setslingload
+syn keyword sqfCommand      setsoundeffect setspeaker setspeech setspeedmode setstamina setstaminascheme setstatvalue
+syn keyword sqfCommand      setsuppression setsystemofunits settargetage settaskmarkeroffset settaskresult settaskstate
+syn keyword sqfCommand      setterraingrid settext settimemultiplier settitleeffect settrafficdensity settrafficdistance
+syn keyword sqfCommand      settrafficgap settrafficspeed settriggeractivation settriggerarea settriggerstatements
+syn keyword sqfCommand      settriggertext settriggertimeout settriggertype settype setunconscious setunitability
+syn keyword sqfCommand      setunitloadout setunitpos setunitposweak setunitrank setunitrecoilcoefficient setunittrait
+syn keyword sqfCommand      setunloadincombat setuseractiontext setusermfdtext setusermfdvalue setvariable setvectordir
+syn keyword sqfCommand      setvectordirandup setvectorup setvehicleammo setvehicleammodef setvehiclearmor
+syn keyword sqfCommand      setvehiclecargo setvehicleid setvehiclelock setvehicleposition setvehicleradar
+syn keyword sqfCommand      setvehiclereceiveremotetargets setvehiclereportownposition setvehiclereportremotetargets
+syn keyword sqfCommand      setvehicletipars setvehiclevarname setvelocity setvelocitymodelspace
+syn keyword sqfCommand      setvelocitytransformation setviewdistance setvisibleiftreecollapsed setwantedrpmrtd setwaves
+syn keyword sqfCommand      setwaypointbehaviour setwaypointcombatmode setwaypointcompletionradius
+syn keyword sqfCommand      setwaypointdescription setwaypointforcebehaviour setwaypointformation
+syn keyword sqfCommand      setwaypointhouseposition setwaypointloiterradius setwaypointloitertype setwaypointname
+syn keyword sqfCommand      setwaypointposition setwaypointscript setwaypointspeed setwaypointstatements
+syn keyword sqfCommand      setwaypointtimeout setwaypointtype setwaypointvisible setweaponreloadingtime setwind
+syn keyword sqfCommand      setwinddir setwindforce setwindstr setwingforcescalertd setwppos show3dicons showchat
+syn keyword sqfCommand      showcinemaborder showcommandingmenu showcompass showcuratorcompass showgps showhud
+syn keyword sqfCommand      showlegend showmap shownartillerycomputer shownchat showncompass showncuratorcompass
+syn keyword sqfCommand      showneweditorobject showngps shownhud shownmap shownpad shownradio shownscoretable
+syn keyword sqfCommand      shownuavfeed shownwarrant shownwatch showpad showradio showscoretable showsubtitles
+syn keyword sqfCommand      showuavfeed showwarrant showwatch showwaypoint showwaypoints side sideambientlife sidechat
+syn keyword sqfCommand      sideempty sideenemy sidefriendly sidelogic sideradio simpletasks simulationenabled
+syn keyword sqfCommand      simulclouddensity simulcloudocclusion simulinclouds simulweathersync sin size sizeof skill
+syn keyword sqfCommand      skillfinal skiptime sliderposition sliderrange slidersetposition slidersetrange
+syn keyword sqfCommand      slidersetspeed sliderspeed slingloadassistantshown soldiermagazines someammo sort
+syn keyword sqfCommand      soundvolume speaker speed speedmode splitstring sqrt squadparams stance startloadingscreen
+syn keyword sqfCommand      step stop stopenginertd stopped str sunormoon supportinfo suppressfor surfaceiswater
+syn keyword sqfCommand      surfacenormal surfacetype swimindepth switchableunits switchaction switchcamera
+syn keyword sqfCommand      switchgesture switchlight switchmove synchronizedobjects synchronizedtriggers
+syn keyword sqfCommand      synchronizedwaypoints synchronizeobjectsadd synchronizeobjectsremove synchronizetrigger
+syn keyword sqfCommand      synchronizewaypoint systemchat systemofunits tan targetknowledge targets targetsaggregate
+syn keyword sqfCommand      targetsquery taskalwaysvisible taskchildren taskcompleted taskcustomdata taskdescription
+syn keyword sqfCommand      taskdestination taskhint taskmarkeroffset taskparent taskresult taskstate tasktype
+syn keyword sqfCommand      teammember teamname teams teamswitch teamswitchenabled teamtype terrainintersect
+syn keyword sqfCommand      terrainintersectasl terrainintersectatasl text textlog textlogformat tg time timemultiplier
+syn keyword sqfCommand      titlecut titlefadeout titleobj titlersc titletext toarray tofixed tolower tostring toupper
+syn keyword sqfCommand      triggeractivated triggeractivation triggerammo triggerarea triggerattachedvehicle
+syn keyword sqfCommand      triggerattachobject triggerattachvehicle triggerdynamicsimulation triggerstatements
+syn keyword sqfCommand      triggertext triggertimeout triggertimeoutcurrent triggertype turretlocal turretowner
+syn keyword sqfCommand      turretunit tvadd tvclear tvcollapse tvcollapseall tvcount tvcursel tvdata tvdelete tvexpand
+syn keyword sqfCommand      tvexpandall tvpicture tvpictureright tvsetcolor tvsetcursel tvsetdata tvsetpicture
+syn keyword sqfCommand      tvsetpicturecolor tvsetpicturecolordisabled tvsetpicturecolorselected tvsetpictureright
+syn keyword sqfCommand      tvsetpicturerightcolor tvsetpicturerightcolordisabled tvsetpicturerightcolorselected
+syn keyword sqfCommand      tvsetselectcolor tvsettext tvsettooltip tvsetvalue tvsort tvsortbyvalue tvtext tvtooltip
+syn keyword sqfCommand      tvvalue type typename typeof uavcontrol uinamespace uisleep unassigncurator unassignitem
+syn keyword sqfCommand      unassignteam unassignvehicle underwater uniform uniformcontainer uniformitems
+syn keyword sqfCommand      uniformmagazines unitaddons unitaimposition unitaimpositionvisual unitbackpack unitisuav
+syn keyword sqfCommand      unitpos unitready unitrecoilcoefficient units unitsbelowheight unlinkitem unlockachievement
+syn keyword sqfCommand      unregistertask updatedrawicon updatemenuitem updateobjecttree useaiopermapobstructiontest
+syn keyword sqfCommand      useaisteeringcomponent useaudiotimeformoves userinputdisabled vectoradd vectorcos
+syn keyword sqfCommand      vectorcrossproduct vectordiff vectordir vectordirvisual vectordistance vectordistancesqr
+syn keyword sqfCommand      vectordotproduct vectorfromto vectorlinearconversion vectormagnitude vectormagnitudesqr
+syn keyword sqfCommand      vectormodeltoworld vectormodeltoworldvisual vectormultiply vectornormalized vectorup
+syn keyword sqfCommand      vectorupvisual vectorworldtomodel vectorworldtomodelvisual vehicle vehiclecargoenabled
+syn keyword sqfCommand      vehiclechat vehicleradio vehiclereceiveremotetargets vehiclereportownposition
+syn keyword sqfCommand      vehiclereportremotetargets vehicles vehiclevarname velocity velocitymodelspace
+syn keyword sqfCommand      verifysignature vest vestcontainer vestitems vestmagazines viewdistance visiblecompass
+syn keyword sqfCommand      visiblegps visiblemap visibleposition visiblepositionasl visiblescoretable visiblewatch
+syn keyword sqfCommand      waves waypointattachedobject waypointattachedvehicle waypointattachobject
+syn keyword sqfCommand      waypointattachvehicle waypointbehaviour waypointcombatmode waypointcompletionradius
+syn keyword sqfCommand      waypointdescription waypointforcebehaviour waypointformation waypointhouseposition
+syn keyword sqfCommand      waypointloiterradius waypointloitertype waypointname waypointposition waypoints
+syn keyword sqfCommand      waypointscript waypointsenableduav waypointshow waypointspeed waypointstatements
+syn keyword sqfCommand      waypointtimeout waypointtimeoutcurrent waypointtype waypointvisible weaponaccessories
+syn keyword sqfCommand      weaponaccessoriescargo weaponcargo weapondirection weaponinertia weaponlowered weapons
+syn keyword sqfCommand      weaponsitems weaponsitemscargo weaponstate weaponsturret weightrtd wfsidetext wind winddir
+syn keyword sqfCommand      windrtd windstr wingsforcesrtd worldname worldsize worldtomodel worldtomodelvisual
+syn keyword sqfCommand      worldtoscreen
 
-syn keyword     sqfRepeat       do for foreach from to while
+syn keyword sqfKeyword      call callextension execfsm execvm exitwith scriptdone sleep spawn terminate waituntil
 
-syn keyword     sqfKeyword      call callextension execfsm execvm exitwith private scriptdone sleep spawn terminate
-syn keyword     sqfKeyword      waituntil
+syn keyword sqfRepeat       do for foreach from to while
 
-syn keyword     sqfStatement    commandfsm compile compilefinal count dofsm preprocessfile preprocessfilelinenumbers
+syn keyword sqfConditional  case default else if switch then with
 
-syn keyword     sqfConditional  case default else if switch then
+syn keyword sqfExceptional  catch throw try
 
-syn keyword     sqfConstant     civilian controlnull displaynull east grpnull independent locationnull netobjnull nil
-syn keyword     sqfConstant     objnull resistance scriptnull sideunknown tasknull teammembernull west
+syn keyword sqfStatement    commandfsm compile compilefinal count dofsm preprocessfile preprocessfilelinenumbers
 
-syn keyword     sqfBoolean      false no true yes
+syn keyword sqfConstant     civilian controlnull displaynull east grpnull independent locationnull netobjnull nil
+syn keyword sqfConstant     objnull resistance scriptnull sideunknown tasknull teammembernull west
 
-syn keyword     sqfOperator     ! != % && * + - / : < <= == > >= >> \|| ^
+syn keyword sqfBoolean      false true
 
-syn keyword     sqfExceptional  catch throw try
+syn keyword sqfType         private
+" END GEN
 
-syn keyword     sqfNamespace    with
+" Command and array operator (non-keyword)
+syn match   sqfCommand      "#"
 
+" Operators
+syn match   sqfOperator     ">>\|&&\|||"
+syn match   sqfOperator     "[!*/%<>^=,+-]"
+syn match   sqfOperator     "&&\|||"
+syn match   sqfOperator     "[][]"
 
-" Other weird stuff
+" Misc
+syn keyword sqfTodo         TODO FIXME XXX contained
+syn match   sqfFormat       display "%\d\+" contained
 
-syn region      sqfString       start=+L\="+ end=+"+
+" Data Types
+syn match   sqfNumber       display "\<\d\+\>"
+syn region  sqfString       start=+L\="+ end=+"+ contains=sqfFormat,sqfNumber
 
-syn region      sqfComment      start="/\*" end="\*/" extend
-syn region      sqfCommentL     start="//" skip="\\$" end="$" keepend
+" Comments
+syn region  sqfCommentL     start="//" skip="\\$" end="$" keepend contains=sqfTodo
+syn region  sqfComment      start="/\*" end="\*/" extend contains=sqfTodo
 
-syn region      sqfIncluded     display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn match       sqfIncluded     display contained "<[^>]*>"
-syn match       sqfInclude      display "^\s*\(%:\|#\)\s*include\>\s*["<]" contains=sqfIncluded
-syn region      sqfPreProc      start="^\s*\(%:\|#\)\s*\(ifn\?def\|else\|endif\)" skip="\\$" end="$" keepend
-syn region      sqfDefine       start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip="\\$" end="$" keepend
-syn match       sqfNumber       display "\<\d\+\>"
+" Preprocessor
+syn region  sqfIncluded     display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match   sqfIncluded     display contained "<[^>]*>"
+syn match   sqfInclude      display "^\s*\(%:\|#\)\s*include\>\s*["<]" contains=sqfIncluded
+syn region  sqfPreProc      start="^\s*\(%:\|#\)\s*\(ifn\?def\|else\|endif\)" skip="\\$" end="$" keepend
+syn region  sqfDefine       start="^\s*\(%:\|#\)\s*\(define\|undef\)\>" skip="\\$" end="$" keepend
+syn match   sqfMacro        "\<\h\w*\>\(\s\|\n\)*("me=e-1
 
-syn region      sqfLocalVar     display start="\<_\w" end="\>"
+" Delimiters
+syn match   sqfBraces       display "[{}]"
+syn match   sqfDelimiter    "[();\\]"
 
 let b:current_syntax = "sqf"
 
-hi def link     sqfComment      Comment
-hi def link     sqfCommentL     Comment
-hi def link     sqfDefine       Macro
-hi def link     sqfInclude      Include
-hi def link     sqfIncluded     String
-hi def link     sqfLocalVar     Special
-hi def link     sqfNumber       Number
-hi def link     sqfPreProc      PreProc
-hi def link     sqfString       String
-hi def link     sqfFunction     Function
-hi def link     sqfCommand      Function
-hi def link     sqfRepeat       Repeat
-hi def link     sqfKeyword      Keyword
-hi def link     sqfStatement    Statement
-hi def link     sqfConditional  Conditional
-hi def link     sqfConstant     Constant
-hi def link     sqfBoolean      Boolean
-hi def link     sqfOperator     Operator
-hi def link     sqfExceptional  Exceptional
-hi def link     sqfNamespace    Namespace
+hi def link sqfOperator     Operator
+hi def link sqfTodo         Todo
+hi def link sqfFormat       Special
+hi def link sqfNumber       Number
+hi def link sqfString       String
+hi def link sqfCommentL     sqfComment
+hi def link sqfComment      Comment
+hi def link sqfIncluded     sqfString
+hi def link sqfInclude      Include
+hi def link sqfPreProc      PreProc
+hi def link sqfDefine       Macro
+hi def link sqfMacro        Function
+hi def link sqfBraces       sqfDelimiter
+hi def link sqfDelimiter    Delimiter
+
+" START HI GEN
+hi def link sqfCommand      Special
+hi def link sqfKeyword      Keyword
+hi def link sqfRepeat       Repeat
+hi def link sqfConditional  Conditional
+hi def link sqfExceptional  Exceptional
+hi def link sqfStatement    Statement
+hi def link sqfConstant     Constant
+hi def link sqfBoolean      Boolean
+hi def link sqfType         Type
+" END HI GEN


### PR DESCRIPTION
**Syntax:**
- Updated header:
  - Added Maintainers (@sqwishy and myself, if @sqwishy wants, can remove otherwise)
  - Changed "Original Author" to "Author"
  - Changed "Last modified for..." to "Version" with date and Arma version
- Add comments throughout the file
- Decrease spacing (using minimal where all `syn` modes fit)
- Removed `no` and `yes` `sqfBooleans` -> not valid SQF
- Added `private` `sqfType` -> slightly different from Special
- Changed Operators to `syn match` so they can actually be highlighted (`syn keyword` keywords must be in `iskeyword`)
  - Added `[]` as operator
- Added `sqfTodo` (from C, makes eg. `TODO` in comment stand out)
- Added `sqfFormat` (from C, modified for SQF, makes `%1` in strings stand out)
- Allowed Number to be contained in String (makes it stand out mildly)
- Added `sqfMacro` (from C, styled as `Function` as in C where functions and macros are used the same way)
- Added `sqfBraces` and `sqfDelimiter` (from C, highlights `()`/`{}`)
- ~~Changed `sqfCommand` to `Special` (was `Function`) to differentiate from `sqfMacro` and conform to how it looks on GitHub~~ actually looks way better and more distinguishable as it was and same as `sqfMacro`
- Moved `with` from `sqfNamespace` to `sqfConditional` as it fits more and also makes more sense (`sqfNamespace` would make sense for `profileNamespace`, `missionNamespace` etc.)
- Fixed `#` highlighting (not in `iskeyword`)

**Generator:**
- Improve command-retrieval instructions (`supportInfo`) comment
- Actually use `LINE_PREFIX_WIDTH` (and decrease it to 28 for less spacing)
- Update syntax file by regex replacing between `START`/`END` markers
  - Reorganize predefined data
  - Remove hardcoded data
- Add `syn` attribute so non-keywords may also be defined (unused currently)
- Write date of generation and Arma version to syntax header (regex replace)
- Close open files properly (`argparse` does not handle that)

Closes #1, but doesn't actually change what #1 was about, as I found out it was equally good if not better.

Overall, this PR improves the styling and makes it somewhat consistent with C/C++ syntax files, with minor SQF-specific changes. It is also similar to GitHub highlighting with some more color distinctions. Maintenance is made even easier and syntax file can be edited directly without worry (except within `START`/`END` tags).

**Includes #3! Merge after #3 or merge #3 together with this one!"**